### PR TITLE
[codex] Fix citation syntax in joint design note

### DIFF
--- a/content/notes/Joint sequence-structure diffusion or flow matching models show superior performance when designing structure at the beginning and sequence near the end.md
+++ b/content/notes/Joint sequence-structure diffusion or flow matching models show superior performance when designing structure at the beginning and sequence near the end.md
@@ -5,11 +5,11 @@ tags:
   - protein-design/design
   - inverse-folding/evaluation
 created: "2026-06-12T09:32:33"
-modified: "2026-06-12T10:15:30"
+modified: "2026-06-12T10:37:47"
 ---
 
 #### Summary
-**Joint sequence/structure [[diffusion-models|diffusion models]] or [[Flow matching|flow matching models]] show best performance when structure design is done at the beginning and sequence design is left to the end[@didi2026a; @staerk2025; @rectorbrooks2026, @qiu2026].** DISCO specifically found that including entropy-adaptive temperature annealing throughout the diffusion process improved both the number of viable clusters and the designability fraction, particularly when the sequence sampling temperature was fixed at a specific value[@rectorbrooks2026]. 
+**Joint sequence/structure [[diffusion-models|diffusion models]] or [[Flow matching|flow matching models]] show best performance when structure design is done at the beginning and sequence design is left to the end [@didi2026a; @staerk2025; @rectorbrooks2026; @qiu2026].** DISCO specifically found that including entropy-adaptive temperature annealing throughout the diffusion process improved both the number of viable clusters and the designability fraction, particularly when the sequence sampling temperature was fixed at a specific value [@rectorbrooks2026]. 
 
 #### Figures
 ![[DISCO-temperature-switch-ablation.png]]
@@ -17,4 +17,3 @@ modified: "2026-06-12T10:15:30"
 
 #### See also
 * [[Coupling sidechain and main chain prediction or design does not always lead to improvements]]
-


### PR DESCRIPTION
## Summary
- Fixes malformed Pandoc citation syntax in the joint sequence-structure design note.
- Changes the comma-separated citation group to semicolon-separated citation keys and adds spaces before citation groups.

## Error investigation
- The Quartz build failed with Cannot read properties of undefined (reading toLowerCase) while processing the new note.
- Root cause: the citation group used [@rectorbrooks2026, @qiu2026], but Pandoc citation groups require semicolons between citation keys.

## Validation
- ./quartz/bootstrap-cli.mjs build passes.