### PR TITLE
[codex] Document ipTM and ipSAE metrics

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1446,6 +1446,15 @@
   url = {https://doi.org/10.1038/s42003-025-08388-y},
 }
 
+@misc{dunbrack2025,
+  title = {Res ipSAE loquuntur: What's wrong with AlphaFold's ipTM score and how to fix},
+  author = {Dunbrack, Roland L.},
+  year = {2025},
+  publisher = {openRxiv},
+  doi = {10.1101/2025.02.10.637595},
+  url = {https://doi.org/10.1101/2025.02.10.637595},
+}
+
 @article{durannebreda2024,
   title = {On the multiscale dynamics of punctuated evolution},
   author = {Duran-Nebreda, Salva and Bentley, R. Alexander and Vidiella, Blai and Spiridonov, Andrej and Eldredge, Niles and O’Brien, Michael J. and Valverde, Sergi},
@@ -1539,6 +1548,15 @@
   pages = {1782-1797},
   doi = {10.1021/acs.jcim.4c01877},
   url = {https://doi.org/10.1021/acs.jcim.4c01877},
+}
+
+@misc{evans2021,
+  title = {Protein complex prediction with AlphaFold-Multimer},
+  author = {Evans, Richard and O'Neill, Michael and Pritzel, Alexander and Antropova, Natasha and Senior, Andrew and Green, Tim and Zidek, Augustin and Bates, Russ and Blackwell, Sam and Yim, Jason and Ronneberger, Olaf and Bodenstein, Sebastian and Zielinski, Michal and Bridgland, Alex and Potapenko, Anna and Cowie, Andrew and Tunyasuvunakool, Kathryn and Jain, Rishub and Clancy, Ellen and Kohli, Pushmeet and Jumper, John and Hassabis, Demis},
+  year = {2021},
+  publisher = {openRxiv},
+  doi = {10.1101/2021.10.04.463034},
+  url = {https://doi.org/10.1101/2021.10.04.463034},
 }
 
 @misc{evans2025,

--- a/content/tags/pae.md
+++ b/content/tags/pae.md
@@ -3,10 +3,10 @@ title: Predicted aligned error
 aliases:
   - Predicted aligned error
 created: "2026-04-10T14:02:57"
-modified: "2026-04-20T10:13:23"
+modified: "2026-06-23T11:45:43"
 ---
 
-**Predicted aligned error** (PAE) is a measurement calculated by protein [[structure-prediction|structure prediction]] neural networks to capture positional errors between two amino acids in a computational model. It was introduced by [[alphafold2|AlphaFold2]]. A derivative metric, ipSAE, has been shown to be more robust at identifying potential binders.
+**Predicted aligned error** (PAE) is a measurement calculated by protein [[structure-prediction|structure prediction]] neural networks to capture positional errors between two amino acids in a computational model. It was introduced by [[alphafold2|AlphaFold2]]. A derivative metric, [[tm-score|ipSAE]], has been shown to be more robust at identifying potential binders.
 
 ![[Pasted-image-20260327091043.png]]
 _Figure from [@chow2025]_

--- a/content/tags/tm-score.md
+++ b/content/tags/tm-score.md
@@ -2,8 +2,10 @@
 title: TM-score
 aliases:
   - TM-score
+  - ipTM
+  - ipSAE
 created: "2024-06-26T13:44:46"
-modified: "2026-04-20T10:13:23"
+modified: "2026-06-23T11:45:43"
 ---
 
 #### Summary
@@ -18,3 +20,33 @@ $L_{target}$: length of the amino acid sequence of the target protein
 $L_{common}$: number of residues in both the target and query proteins
 $d$: Distance between pairs of residues
 $d_{0}(L_{target}) = 1.24*\sqrt[3]{L_{target}-15}-1.8$: Distance scaling factor
+
+#### Predicted variants
+
+[[structure-prediction|Protein folding neural networks]] such as [[alphafold2|AlphaFold2]] and [[alphafold3|AlphaFold3]] predict a distribution over aligned errors for each ordered residue pair, then use that distribution to calculate pTM and ipTM confidence scores [@jumper2021; @evans2021]. For bin center $\Delta_b$ and probability $p_{ijb}$, the expected TM contribution for a residue pair is:
+
+$$
+E_{ij} = \sum_b p_{ijb}\frac{1}{1+\left(\frac{\Delta_b}{d_0(L)}\right)^2}
+$$
+
+**ipTM** (interface predicted TM-score) uses this same TM-score transform, but masks the average to residues in other chains:
+
+$$
+ipTM = \max_i \left[\frac{1}{|J_i|}\sum_{j \in J_i} E_{ij}\right], \quad J_i = \{j : chain(j) \ne chain(i)\}
+$$
+
+$L$ is the number of modeled residues used for $d_0$. In practice, ipTM is an inter-chain pTM score rather than a direct interface-contact score: all residues in other chains can contribute, not just residues close in 3D.
+
+**ipSAE** (interaction prediction score from aligned errors) is a [[pae|PAE]]-derived replacement for ipTM calculated after choosing a PAE cutoff $\tau$ [@dunbrack2025]. For a chain direction $A \to B$ and aligned residue $i \in A$, it keeps only residues in the other chain with $PAE_{ij}<\tau$ and computes:
+
+$$
+pSAE_i(A \to B)= \frac{1}{|S_i|} \sum_{j \in S_i}\frac{1}{1+\left(\frac{PAE_{ij}}{d_0(|S_i|)}\right)^2}, \quad S_i = \{j \in B: PAE_{ij}<\tau\}
+$$
+
+Then:
+
+$$
+ipSAE(A \to B)=\max_{i \in A} pSAE_i(A \to B)
+$$
+
+The reported pairwise "max" score is the maximum of the two chain directions. Compared with ipTM, ipSAE specifically improves robustness to construct length, disordered tails, and accessory domains because it scores only confident inter-chain residue pairs, uses a local $d_0$ based on those residues rather than full chain/complex length, and uses the output PAE matrix rather than requiring AlphaFold's internal aligned-error logits [@dunbrack2025].


### PR DESCRIPTION
## Summary

- Expand the TM-score note with pTM/ipTM calculation details for protein folding neural networks.
- Add the ipSAE calculation and explain what it improves over ipTM.
- Link the existing ipSAE mention in the PAE note back to the TM-score note.
- Add bibliography entries for AlphaFold-Multimer and the ipSAE preprint.

## Validation

- Ran `npm ci` to install missing Node dependencies.
- Ran `./quartz/bootstrap-cli.mjs build`; it failed in an unrelated existing note: `content/notes/Joint sequence-structure diffusion or flow matching models show superior performance when designing structure at the beginning and sequence near the end.md` with `Cannot read properties of undefined (reading 'toLowerCase')`.