### PR TITLE
Fix Pages build and require PR site builds

### DIFF
--- a/.github/workflows/site-build.yaml
+++ b/.github/workflows/site-build.yaml
@@ -1,0 +1,34 @@
+name: Site build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  site-build:
+    name: Site build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npx quartz build

--- a/content/notes/Distograms can be used as loss functions for protein design by hallucination.md
+++ b/content/notes/Distograms can be used as loss functions for protein design by hallucination.md
@@ -2,7 +2,7 @@
 tags:
   - protein-design
 created: "2026-07-17T09:42:26"
-modified: "2026-07-17T09:42:26"
+modified: "2026-07-22T09:19:35"
 ---
 #### Summary
-**[[distograms|Distograms]] from [[structure-prediction|protein structure prediction neural networks]] can be used as loss functions for [[protein-design|protein design]]** [@cho2025b, @candido2026]. This has been experimentally validated for both miniprotein binders and [[antibodies]] in the case of ESMFold2.
+**[[distograms|Distograms]] from [[structure-prediction|protein structure prediction neural networks]] can be used as loss functions for [[protein-design|protein design]]** [@cho2025b; @candido2026]. This has been experimentally validated for both miniprotein binders and [[antibodies]] in the case of ESMFold2.


### PR DESCRIPTION
## What changed

- Fix the malformed comma-separated citation that caused the Quartz build to crash.
- Add a read-only `Site build` GitHub Actions check for every pull request.
- Run `npm ci` and a complete `npx quartz build` with per-PR concurrency cancellation.

## Root cause

The Distograms note used `[@cho2025b, @candido2026]`. Quartz's citation processor expects multiple citation keys to be separated with semicolons, so it produced an undefined citation entry and failed while reading `toLowerCase`.

## Impact

Pull requests will now expose deployment-breaking content or configuration errors before they reach `main`. The existing Pages deployment workflow remains unchanged.

## Verification

- `npx --no-install prettier .github/workflows/site-build.yaml --check`
- `npm ci`
- `npx quartz build` (793 Markdown files; 2,214 files emitted)
