### PR TITLE
Fix PubMed daily discovery window

### DIFF
--- a/scripts/paperbot/daily.py
+++ b/scripts/paperbot/daily.py
@@ -198,13 +198,14 @@ def run_daily(
   if model.model_hash != model_manifest.get("model_hash"):
     raise ValueError("loaded classifier does not match the verified model manifest")
 
+  client = github_client or GitHubClient(config.repository, github_token)
+  issue_index = load_managed_issues(client)
   report = fetch_report or fetch_all_sources(
     window,
     contact_email=config.contact_email,
     ncbi_api_key=ncbi_api_key,
+    known_pubmed_ids=_managed_pubmed_ids(issue_index),
   )
-  client = github_client or GitHubClient(config.repository, github_token)
-  issue_index = load_managed_issues(client)
   bibliography = BibliographyIndex.load(config.bibliography_path)
   candidates = _prepare_candidates(report.records, bibliography, issue_index, model.model_hash)
 
@@ -328,6 +329,20 @@ def run_daily(
     feed_errors=tuple(_failure_dict(error) for error in report.errors),
     publish_errors=tuple(publish_errors),
   )
+
+
+def _managed_pubmed_ids(issues: ManagedIssueIndex) -> tuple[str, ...]:
+  """Return PMIDs whose managed issues should be checked for revisions."""
+
+  pmids = {
+    alias.removeprefix("pmid:")
+    for issue in issues.issues
+    for alias in issue.meta.get("aliases", [])
+    if isinstance(alias, str)
+    and alias.startswith("pmid:")
+    and alias.removeprefix("pmid:").isdigit()
+  }
+  return tuple(sorted(pmids, key=int))
 
 
 def write_project_queue(

--- a/scripts/paperbot/model.py
+++ b/scripts/paperbot/model.py
@@ -187,6 +187,12 @@ class Specter2Encoder:
       return np.empty((0, EMBEDDING_DIMENSION), dtype=np.float32)
     outputs = []
     separator = self.tokenizer.sep_token or "[SEP]"
+    total = len(documents)
+    print(
+      f"paperbot: embedding {total} documents with SPECTER2 "
+      f"in batches of {self.batch_size}",
+      flush=True,
+    )
     with self._torch.inference_mode():
       for start in range(0, len(documents), self.batch_size):
         batch = documents[start : start + self.batch_size]
@@ -202,6 +208,10 @@ class Specter2Encoder:
         hidden = self.model(**tokens).last_hidden_state[:, 0, :]
         hidden = hidden / hidden.norm(p=2, dim=1, keepdim=True).clamp_min(1e-12)
         outputs.append(hidden.detach().cpu().to(self._torch.float32).numpy())
+        completed = min(start + len(batch), total)
+        batch_number = start // self.batch_size + 1
+        if completed == total or batch_number % 100 == 0:
+          print(f"paperbot: embedded {completed}/{total} documents", flush=True)
     matrix = np.concatenate(outputs, axis=0).astype(np.float32, copy=False)
     _validate_matrix(matrix, len(documents), "SPECTER2 output")
     return matrix

--- a/scripts/paperbot/sources.py
+++ b/scripts/paperbot/sources.py
@@ -105,6 +105,12 @@ class FetchWindow:
     timestamp = ensure_utc(value)
     return timestamp is not None and self.query_since <= timestamp < self.until
 
+  def includes_logical_timestamp(self, value: datetime | date | str | None) -> bool:
+    """Return whether ``value`` belongs to the run's exact logical tranche."""
+
+    timestamp = ensure_utc(value)
+    return timestamp is not None and self.logical_since <= timestamp < self.until
+
   @property
   def query_end_date(self) -> date:
     """Last provider date included by the half-open ``[since, until)`` window."""
@@ -398,9 +404,46 @@ def _pubmed_date(node: ET.Element | None) -> datetime | None:
     day = int(_xml_text(node.find("Day")) or "1")
     hour = int(_xml_text(node.find("Hour")) or "0")
     minute = int(_xml_text(node.find("Minute")) or "0")
-    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+    second = int(_xml_text(node.find("Second")) or "0")
+    return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
   except ValueError:
     return datetime(year, 1, 1, tzinfo=UTC)
+
+
+def _pubmed_date_precision(node: ET.Element | None) -> str:
+  """Describe the finest timestamp component supplied by PubMed."""
+
+  if node is None:
+    return "day"
+  for field, precision in (
+    ("Second", "second"),
+    ("Minute", "minute"),
+    ("Hour", "hour"),
+    ("Day", "day"),
+    ("Month", "month"),
+    ("Year", "year"),
+  ):
+    if _xml_text(node.find(field)):
+      return precision
+  return "day"
+
+
+def _pubmed_entrez_date_node(item: ET.Element, *, is_book: bool) -> ET.Element | None:
+  """Find PubMed's precise timestamp for first addition to the database."""
+
+  history_path = (
+    "./PubmedBookData/History/PubMedPubDate"
+    if is_book
+    else "./PubmedData/History/PubMedPubDate"
+  )
+  return next(
+    (
+      node
+      for node in item.findall(history_path)
+      if node.attrib.get("PubStatus", "").casefold() == "entrez"
+    ),
+    None,
+  )
 
 
 def _pubmed_date_text(node: ET.Element | None) -> str:
@@ -518,6 +561,8 @@ def parse_pubmed_xml(payload: bytes) -> list[PaperRecord]:
           doi = normalize_doi(_xml_text(identifier))
           if doi:
             break
+    entrez_date_node = _pubmed_entrez_date_node(item, is_book=is_book)
+    entrez_date = _pubmed_date(entrez_date_node)
     if is_book:
       history_dates = item.findall("./PubmedBookData/History/PubMedPubDate")
       history_by_status = {
@@ -525,7 +570,7 @@ def parse_pubmed_xml(payload: bytes) -> list[PaperRecord]:
         for node in history_dates
       }
       created = (
-        history_by_status.get("entrez")
+        entrez_date
         or history_by_status.get("pubmed")
         or history_by_status.get("medline")
       )
@@ -535,7 +580,7 @@ def parse_pubmed_xml(payload: bytes) -> list[PaperRecord]:
       publication_date = _pubmed_date_text(publication_node)
       venue = _xml_text(item.find("./BookDocument/Book/BookTitle"))
     else:
-      created = _pubmed_date(item.find("./MedlineCitation/DateCreated"))
+      created = entrez_date or _pubmed_date(item.find("./MedlineCitation/DateCreated"))
       updated = _pubmed_date(item.find("./MedlineCitation/DateRevised")) or created
       published = _pubmed_publication_date(item)
       publication_date = _pubmed_publication_date_text(item)
@@ -555,7 +600,9 @@ def parse_pubmed_xml(payload: bytes) -> list[PaperRecord]:
         pmid=pmid,
         related_ids=tuple(related),
         metadata={
-          "timestamp_precision": "day",
+          "timestamp_precision": (
+            _pubmed_date_precision(entrez_date_node) if entrez_date else "day"
+          ),
           **({"publication_year": published.year} if published else {}),
           **({"publication_date": publication_date} if publication_date else {}),
         },
@@ -709,38 +756,41 @@ def fetch_pubmed(
   *,
   contact_email: str = "",
   api_key: str = "",
+  known_pubmed_ids: Iterable[str] = (),
   search_page_size: int = 5_000,
   fetch_batch_size: int = 200,
 ) -> SourceResult:
   result = SourceResult("pubmed")
-  ids: set[str] = set()
+  managed_ids = {
+    value
+    for raw_value in known_pubmed_ids
+    if (value := str(raw_value).strip()).isdigit()
+  }
+  ids = set(managed_ids)
   interval = 0.11 if api_key else 0.34
   common: dict[str, Any] = {"db": "pubmed", "tool": "SKM-paperbot"}
   if contact_email:
     common["email"] = contact_email
   if api_key:
     common["api_key"] = api_key
-  for day in _calendar_days(window.query_since.date(), window.query_end_date):
+  for day in _calendar_days(window.logical_since.date(), window.query_end_date):
     stamp = day.strftime("%Y/%m/%d")
-    # Query the two date fields separately. Besides making provenance explicit,
-    # this avoids needlessly combining two large daily sets before UID-range
-    # partitioning around PubMed's hard 9,999-result retrieval ceiling.
-    for date_field in ("CRDT", "LR"):
-      term = f'"{stamp}"[{date_field}] AND hasabstract'
-      try:
-        ids.update(
-          _pubmed_collect_term_ids(
-            client,
-            common,
-            base_term=term,
-            page_size=search_page_size,
-            interval=interval,
-          )
+    # CRDT represents first addition to PubMed. Global LR queries also include
+    # routine indexing edits to older records and make a daily discovery run
+    # unnecessarily enormous. Revisions are checked through ``managed_ids``.
+    term = f'"{stamp}"[CRDT] AND hasabstract'
+    try:
+      ids.update(
+        _pubmed_collect_term_ids(
+          client,
+          common,
+          base_term=term,
+          page_size=search_page_size,
+          interval=interval,
         )
-      except Exception as error:
-        result.errors.append(
-          _failure("pubmed", f"search {date_field} {day.isoformat()}", error)
-        )
+      )
+    except Exception as error:
+      result.errors.append(_failure("pubmed", f"search CRDT {day.isoformat()}", error))
   ordered_ids = sorted(ids, key=int)
   for start in range(0, len(ordered_ids), fetch_batch_size):
     batch = ordered_ids[start : start + fetch_batch_size]
@@ -778,7 +828,7 @@ def fetch_pubmed(
       if record.pmid not in batch:
         result.skipped += 1
         continue
-      if window.includes_query_date(record.updated_at or record.created_at):
+      if record.pmid in managed_ids or window.includes_logical_timestamp(record.created_at):
         result.records.append(record)
       else:
         result.skipped += 1
@@ -1507,6 +1557,7 @@ def fetch_all_sources(
   client: HttpClientProtocol | None = None,
   contact_email: str = "",
   ncbi_api_key: str = "",
+  known_pubmed_ids: Iterable[str] = (),
   fetchers: Mapping[str, Fetcher] | None = None,
 ) -> FetchReport:
   """Fetch every feed independently and retain successes when peers fail."""
@@ -1520,6 +1571,7 @@ def fetch_all_sources(
       fetch_client,
       contact_email=contact_email,
       api_key=ncbi_api_key,
+      known_pubmed_ids=known_pubmed_ids,
     ),
     "arxiv": fetch_arxiv,
     "biorxiv": lambda fetch_window, fetch_client: fetch_rxiv(
@@ -1532,10 +1584,16 @@ def fetch_all_sources(
   }
   results: list[SourceResult] = []
   for name, fetcher in providers.items():
+    print(f"paperbot: fetching {name}", flush=True)
     try:
       source_result = fetcher(window, http)
     except Exception as error:
       source_result = SourceResult(name, errors=[_failure(name, "fetch", error)])
+    print(
+      f"paperbot: completed {name}: {len(source_result.records)} records, "
+      f"{len(source_result.errors)} errors",
+      flush=True,
+    )
     results.append(source_result)
   records = deduplicate_records(
     record for source_result in results for record in source_result.records

--- a/tests/paperbot/test_daily.py
+++ b/tests/paperbot/test_daily.py
@@ -14,6 +14,7 @@ from scripts.paperbot.config import PaperbotConfig
 from scripts.paperbot.cli import main as paperbot_main
 from scripts.paperbot.daily import (
   BibliographyIndex,
+  _managed_pubmed_ids,
   _prepare_candidates,
   run_daily,
   sync_project_queue,
@@ -214,6 +215,49 @@ def test_unchanged_candidate_is_not_embedded(tmp_path: Path) -> None:
 
   assert result.candidates[0].action == "unchanged"
   assert scorer.call_args.args[0] == []
+
+
+def test_daily_limits_pubmed_revision_checks_to_managed_issue_pmids(
+  tmp_path: Path,
+) -> None:
+  config = make_config(
+    tmp_path,
+    "@article{other2025, title={Other}, author={Other, A}, year={2025}, "
+    "abstract={Other abstract.}, doi={10.1000/other}}\n",
+  )
+  client = MemoryIssueClient()
+  current = record()
+  bibliography = BibliographyIndex.load(config.bibliography_path)
+  prepared = _prepare_candidates(
+    [current], bibliography, load_managed_issues(client), "model"
+  )[0]
+  upsert_paper_issue(
+    client,  # type: ignore[arg-type]
+    current,
+    0.9,
+    prepared.bibtex,
+    prepared.bibkey,
+    model_hash="model",
+  )
+  window = FetchWindow.ending_at(datetime(2026, 7, 22, tzinfo=UTC))
+  empty = FetchReport(window, (), (), {"pubmed": 0})
+
+  with (
+    patch("scripts.paperbot.daily.check_model", return_value={"model_hash": "model"}),
+    patch("scripts.paperbot.daily.load_model", return_value=LoadedModel(None, 0, "model")),
+    patch("scripts.paperbot.daily.fetch_all_sources", return_value=empty) as fetcher,
+    patch("scripts.paperbot.daily._score", return_value=[]),
+  ):
+    run_daily(
+      config,
+      window,
+      dry_run=True,
+      github_token="token",
+      github_client=client,  # type: ignore[arg-type]
+    )
+
+  assert _managed_pubmed_ids(load_managed_issues(client)) == ("12345",)
+  assert fetcher.call_args.kwargs["known_pubmed_ids"] == ("12345",)
 
 
 def test_daily_publishes_issues_without_project_configuration_or_token(

--- a/tests/paperbot/test_sources.py
+++ b/tests/paperbot/test_sources.py
@@ -59,6 +59,12 @@ PUBMED_XML = b"""<?xml version="1.0"?>
       </Article>
     </MedlineCitation>
     <PubmedData>
+      <History>
+        <PubMedPubDate PubStatus="entrez">
+          <Year>2026</Year><Month>07</Month><Day>21</Day>
+          <Hour>12</Hour><Minute>34</Minute><Second>56</Second>
+        </PubMedPubDate>
+      </History>
       <ArticleIdList>
         <ArticleId IdType="pubmed">123456</ArticleId>
         <ArticleId IdType="doi">10.1000/FIXTURE</ArticleId>
@@ -93,6 +99,7 @@ PUBMED_BOOK_XML = b"""<?xml version="1.0"?>
       <History>
         <PubMedPubDate PubStatus="entrez">
           <Year>2026</Year><Month>07</Month><Day>20</Day>
+          <Hour>03</Hour><Minute>04</Minute><Second>05</Second>
         </PubMedPubDate>
       </History>
       <ArticleIdList><ArticleId IdType="pubmed">654321</ArticleId></ArticleIdList>
@@ -122,6 +129,42 @@ def arxiv_xml(
       <arxiv:doi>10.1000/{identifier}</arxiv:doi>
     </entry>
   </feed>""".encode()
+
+
+def pubmed_xml_at(pmid: str, entered_at: datetime) -> bytes:
+  """Return one minimal PubMed article with an exact Entrez timestamp."""
+
+  entered_at = entered_at.astimezone(UTC)
+  return f"""<?xml version="1.0"?>
+  <PubmedArticleSet>
+    <PubmedArticle>
+      <MedlineCitation>
+        <PMID>{pmid}</PMID>
+        <DateCreated>
+          <Year>{entered_at.year}</Year><Month>{entered_at.month:02d}</Month>
+          <Day>{entered_at.day:02d}</Day>
+        </DateCreated>
+        <Article>
+          <ArticleTitle>Boundary fixture {pmid}</ArticleTitle>
+          <Abstract><AbstractText>A complete boundary abstract.</AbstractText></Abstract>
+          <Journal>
+            <JournalIssue><PubDate><Year>2026</Year></PubDate></JournalIssue>
+            <Title>Journal of Boundaries</Title>
+          </Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData>
+        <History>
+          <PubMedPubDate PubStatus="entrez">
+            <Year>{entered_at.year}</Year><Month>{entered_at.month:02d}</Month>
+            <Day>{entered_at.day:02d}</Day><Hour>{entered_at.hour:02d}</Hour>
+            <Minute>{entered_at.minute:02d}</Minute><Second>{entered_at.second:02d}</Second>
+          </PubMedPubDate>
+        </History>
+        <ArticleIdList><ArticleId IdType="pubmed">{pmid}</ArticleId></ArticleIdList>
+      </PubmedData>
+    </PubmedArticle>
+  </PubmedArticleSet>""".encode()
 
 
 def window() -> FetchWindow:
@@ -172,6 +215,9 @@ def test_fetch_window_has_24_hour_tranche_and_72_hour_overlap() -> None:
   assert value.until == datetime(2026, 7, 22, tzinfo=UTC)
   assert value.query_end_date.isoformat() == "2026-07-21"
   assert value.includes_query_timestamp("2026-07-20T12:00:00Z")
+  assert value.includes_logical_timestamp("2026-07-21T00:00:00Z")
+  assert not value.includes_logical_timestamp("2026-07-20T23:59:59Z")
+  assert not value.includes_logical_timestamp("2026-07-22T00:00:00Z")
   assert not value.includes_query_timestamp("2026-07-22T00:00:00Z")
   assert not value.includes_query_date("2026-07-22")
   assert not value.includes_query_timestamp("2026-07-18T23:59:59Z")
@@ -195,7 +241,8 @@ def test_parse_pubmed_xml_preserves_sections_identifiers_and_revision_date() -> 
   assert record.updated_at == datetime(2026, 7, 21, tzinfo=UTC)
   assert record.year == 2024
   assert record.metadata["publication_date"] == "2024-07-20"
-  assert record.created_at == datetime(2026, 7, 21, tzinfo=UTC)
+  assert record.created_at == datetime(2026, 7, 21, 12, 34, 56, tzinfo=UTC)
+  assert record.metadata["timestamp_precision"] == "second"
   assert "pmc:pmc999" in record.related_ids
 
 
@@ -211,14 +258,17 @@ def test_parse_pubmed_book_article_with_abstract() -> None:
   assert record.authors == ("Grace Hopper",)
   assert record.venue == "Fixture Methods"
   assert record.year == 2022
+  assert record.created_at == datetime(2026, 7, 20, 3, 4, 5, tzinfo=UTC)
+  assert record.metadata["timestamp_precision"] == "second"
   assert record.metadata["publication_date"] == "2022"
 
 
-def test_fetch_pubmed_queries_crdt_and_lr_and_deduplicates_search_ids() -> None:
+def test_fetch_pubmed_queries_only_crdt_for_the_logical_window() -> None:
   def get_json(url: str, params: Mapping[str, Any]) -> Any:
     assert url == PUBMED_ESEARCH
     term = str(params["term"])
-    assert ("[CRDT]" in term) != ("[LR]" in term)
+    assert "[CRDT]" in term
+    assert "[LR]" not in term
     if "2026/07/21" in str(params["term"]):
       return {"esearchresult": {"count": "1", "idlist": ["123456"]}}
     return {"esearchresult": {"count": "0", "idlist": []}}
@@ -232,9 +282,67 @@ def test_fetch_pubmed_queries_crdt_and_lr_and_deduplicates_search_ids() -> None:
 
   assert result.ok
   assert len(result.records) == 1
-  assert len([call for call in client.calls if call[1] == PUBMED_ESEARCH]) == 6
+  assert len([call for call in client.calls if call[1] == PUBMED_ESEARCH]) == 1
   assert len([call for call in client.calls if call[1] == PUBMED_EFETCH]) == 1
   assert all(call[3] == 0.34 for call in client.calls)
+
+
+@pytest.mark.parametrize(
+  ("entered_at", "included"),
+  [
+    (datetime(2026, 7, 21, 18, 0, 0, tzinfo=UTC), True),
+    (datetime(2026, 7, 22, 17, 59, 59, tzinfo=UTC), True),
+    (datetime(2026, 7, 21, 17, 59, 59, tzinfo=UTC), False),
+    (datetime(2026, 7, 22, 18, 0, 0, tzinfo=UTC), False),
+  ],
+)
+def test_fetch_pubmed_filters_new_records_by_exact_half_open_window(
+  entered_at: datetime, included: bool
+) -> None:
+  exact_window = FetchWindow.between(
+    datetime(2026, 7, 21, 18, tzinfo=UTC),
+    datetime(2026, 7, 22, 18, tzinfo=UTC),
+  )
+
+  def get_json(_url: str, _params: Mapping[str, Any]) -> Any:
+    return {"esearchresult": {"count": "1", "idlist": ["700001"]}}
+
+  client = RoutingClient(
+    json_route=get_json,
+    bytes_route=lambda _url, _params: pubmed_xml_at("700001", entered_at),
+  )
+  result = fetch_pubmed(exact_window, client)
+
+  assert result.ok
+  assert bool(result.records) is included
+  assert result.skipped == (0 if included else 1)
+  search_terms = [
+    str(call[2]["term"]) for call in client.calls if call[1] == PUBMED_ESEARCH
+  ]
+  assert search_terms == [
+    '"2026/07/21"[CRDT] AND hasabstract',
+    '"2026/07/22"[CRDT] AND hasabstract',
+  ]
+
+
+def test_fetch_pubmed_refetches_known_pmids_outside_discovery_window() -> None:
+  def get_json(_url: str, _params: Mapping[str, Any]) -> Any:
+    return {"esearchresult": {"count": "0", "idlist": []}}
+
+  client = RoutingClient(
+    json_route=get_json,
+    bytes_route=lambda _url, _params: pubmed_xml_at(
+      "700002", datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ),
+  )
+  result = fetch_pubmed(
+    window(), client, known_pubmed_ids={"700002", "not-a-pmid"}
+  )
+
+  assert result.ok
+  assert [record.pmid for record in result.records] == ["700002"]
+  fetch_call = next(call for call in client.calls if call[1] == PUBMED_EFETCH)
+  assert fetch_call[2]["id"] == "700002"
 
 
 def test_pubmed_partitions_uid_space_beyond_the_9999_result_cap() -> None:
@@ -259,7 +367,7 @@ def test_pubmed_partitions_uid_space_beyond_the_9999_result_cap() -> None:
   identifiers = _pubmed_collect_term_ids(
     client,
     {"db": "pubmed"},
-    base_term='"2026/07/20"[LR] AND hasabstract',
+    base_term='"2026/07/20"[CRDT] AND hasabstract',
     page_size=9_999,
     interval=0.34,
   )
@@ -597,7 +705,7 @@ def test_http_error_redacts_common_query_credential_names() -> None:
   assert "page=2" in message
 
 
-def test_fetch_all_sources_isolates_failure_and_deduplicates_successes() -> None:
+def test_fetch_all_sources_isolates_failure_and_reports_progress(capsys: Any) -> None:
   record = PaperRecord(
     source="arxiv",
     source_id="2401.12345",
@@ -624,6 +732,47 @@ def test_fetch_all_sources_isolates_failure_and_deduplicates_successes() -> None
   assert len(report.errors) == 1
   assert report.errors[0].source == "bad"
   assert "provider unavailable" in report.errors[0].message
+  assert capsys.readouterr().out.splitlines() == [
+    "paperbot: fetching good",
+    "paperbot: completed good: 2 records, 0 errors",
+    "paperbot: fetching bad",
+    "paperbot: completed bad: 0 records, 1 errors",
+  ]
+
+
+def test_fetch_all_sources_passes_known_pubmed_ids(monkeypatch: Any) -> None:
+  captured: dict[str, Any] = {}
+
+  def fake_pubmed(
+    _window: FetchWindow,
+    _client: Any,
+    **kwargs: Any,
+  ) -> SourceResult:
+    captured.update(kwargs)
+    return SourceResult("pubmed")
+
+  def fake_rxiv(
+    _window: FetchWindow, _client: Any, *, server: str
+  ) -> SourceResult:
+    return SourceResult(server)
+
+  monkeypatch.setattr("scripts.paperbot.sources.fetch_pubmed", fake_pubmed)
+  monkeypatch.setattr(
+    "scripts.paperbot.sources.fetch_arxiv",
+    lambda _window, _client: SourceResult("arxiv"),
+  )
+  monkeypatch.setattr("scripts.paperbot.sources.fetch_rxiv", fake_rxiv)
+  monkeypatch.setattr(
+    "scripts.paperbot.sources.fetch_chemrxiv",
+    lambda _window, _client: SourceResult("chemrxiv"),
+  )
+
+  report = fetch_all_sources(
+    window(), client=object(), known_pubmed_ids=("123456", "654321")  # type: ignore[arg-type]
+  )
+
+  assert report.ok
+  assert tuple(captured["known_pubmed_ids"]) == ("123456", "654321")
 
 
 def test_invalid_fetch_window_is_rejected() -> None:


### PR DESCRIPTION
## What changed

- discover new PubMed records with `CRDT` only
- filter manual runs using the exact PubMed `entrez` timestamp
- bypass the 72-hour overlap for PubMed discovery
- re-fetch only PMIDs already represented by managed issues to detect revisions
- add flushed provider and SPECTER2 progress output

## Root cause

The original implementation combined PubMed creation dates with the global last-modification (`LR`) feed and expanded a 24-hour manual interval to two complete dates. That produced 22,716 metadata updates rather than one day of newly added citations.

## Validation

- 165 tests and 14 subtests pass
- exact-window NCBI preflight: 3,836 PubMed records, zero errors
- diff validation and compilation pass