### PR TITLE
Train paper relevance from negative-labeled issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Stored vectors are self-consistency checked, but only a maintainer can attest
+# that artifact changes came from the trusted pinned SPECTER2 generator.
+/.github/CODEOWNERS @delalamo
+/.github/workflows/paper-*.yml @delalamo
+/paperbot.toml @delalamo
+/requirements-paperbot.lock @delalamo
+/scripts/paperbot/ @delalamo
+/paper_relevance/ @delalamo
+/tests/paperbot/ @delalamo

--- a/.github/workflows/paper-model-refresh.yml
+++ b/.github/workflows/paper-model-refresh.yml
@@ -3,6 +3,7 @@ name: Refresh paper relevance model
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -20,9 +21,10 @@ jobs:
       contents: read
     outputs:
       relevant: ${{ steps.changes.outputs.relevant }}
+      lock_changed: ${{ steps.changes.outputs.lock_changed }}
     env:
-      BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
     steps:
       - name: Check out candidate history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -38,34 +40,109 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
+            # Manual dispatch can target a feature branch. Validate that
+            # branch's lock in the credential-free job conservatively.
+            echo "lock_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git -C candidate fetch --no-tags --depth=1 \
-            "https://github.com/$GITHUB_REPOSITORY.git" "$BASE_SHA"
-          if git -C candidate diff --quiet --no-renames \
-            "$BASE_SHA...$HEAD_SHA" -- \
-            bibliography.bib \
-            paperbot.toml \
-            requirements-paperbot.lock \
-            conftest.py \
-            pytest.ini \
-            pyproject.toml \
-            setup.cfg \
-            .gitattributes \
-            .lfsconfig \
-            ':(glob)**/.gitattributes' \
-            ':(glob)**/conftest.py' \
-            ':(glob)paper_relevance/**' \
-            ':(glob)scripts/**' \
-            ':(glob)tests/paperbot/**' \
-            .github/workflows/paper-discovery.yml \
-            .github/workflows/paper-model-refresh.yml; then
-            echo "relevant=false" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
+            # A merge group may contain a dependency change from any member.
+            # Testing its assembled head with the candidate lock is the safe
+            # conservative choice.
+            echo "lock_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "::error::Unsupported paperbot workflow event: $GITHUB_EVENT_NAME"
+            exit 1
+          fi
+          git -C candidate fetch --no-tags \
+            "https://github.com/$GITHUB_REPOSITORY.git" "$BASE_SHA"
+          set +e
+          raw_diff=$(git -C candidate diff --raw --no-renames \
+            "$BASE_SHA...$HEAD_SHA")
+          raw_status=$?
+          set -e
+          if [[ "$raw_status" -ne 0 ]]; then
+            echo "::error::Could not inspect changed Git object modes"
+            exit "$raw_status"
+          fi
+          symlink_changed=false
+          while IFS= read -r raw_line; do
+            metadata=${raw_line%%$'\t'*}
+            old_mode=${metadata%% *}
+            old_mode=${old_mode#:}
+            metadata=${metadata#* }
+            new_mode=${metadata%% *}
+            if [[ "$old_mode" == "120000" || "$new_mode" == "120000" ]]; then
+              symlink_changed=true
+              break
+            fi
+          done <<< "$raw_diff"
+          set +e
+          git -C candidate diff --quiet --no-renames \
+            "$BASE_SHA...$HEAD_SHA" -- requirements-paperbot.lock
+          lock_status=$?
+          git -C candidate diff --quiet --no-renames \
+            "$BASE_SHA...$HEAD_SHA" -- \
+              bibliography.bib \
+              paperbot.toml \
+              requirements-paperbot.lock \
+              sitecustomize.py \
+              usercustomize.py \
+              .gitattributes \
+              .gitignore \
+              .lfsconfig \
+              .github/CODEOWNERS \
+              ':(glob)**/.gitattributes' \
+              ':(glob)**/.gitignore' \
+              ':(glob)**/.pytest.ini' \
+              ':(glob)**/.pytest.toml' \
+              ':(glob)**/conftest.py' \
+              ':(glob)**/pyproject.toml' \
+              ':(glob)**/pytest.ini' \
+              ':(glob)**/pytest.toml' \
+              ':(glob)**/setup.cfg' \
+              ':(glob)**/tox.ini' \
+              ':(glob)*.py' \
+              ':(glob)**/*.py' \
+              ':(glob)*.py[cod]' \
+              ':(glob)**/*.py[cod]' \
+              ':(glob)*.so' \
+              ':(glob)**/*.so' \
+              ':(glob)*.pyd' \
+              ':(glob)**/*.pyd' \
+              ':(glob)*.dylib' \
+              ':(glob)**/*.dylib' \
+              ':(glob)paper_relevance/**' \
+              ':(glob)scripts/**' \
+              ':(glob)tests/paperbot/**' \
+              .github/workflows/paper-discovery.yml \
+              .github/workflows/paper-model-refresh.yml
+          relevant_status=$?
+          set -e
+          if [[ "$symlink_changed" == "true" && "$relevant_status" -eq 0 ]]; then
+            relevant_status=1
+          fi
+          case "$lock_status" in
+            0) echo "lock_changed=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "lock_changed=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Could not determine whether the dependency lock changed"
+              exit "$lock_status"
+              ;;
+          esac
+          case "$relevant_status" in
+            0) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Could not determine whether paperbot-relevant paths changed"
+              exit "$relevant_status"
+              ;;
+          esac
 
   paperbot_tests:
     name: Run paperbot unit tests
@@ -101,14 +178,29 @@ jobs:
       # Once paperbot lands, every later PR automatically uses the trusted lock.
       - name: Select dependency source
         id: dependencies
+        env:
+          LOCK_CHANGED: ${{ needs.detect_paperbot_changes.outputs.lock_changed }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$LOCK_CHANGED" != "true" && "$LOCK_CHANGED" != "false" ]]; then
+            echo "::error::Dependency-lock change detection returned an invalid result"
+            exit 1
+          fi
           if [[ -f "$GITHUB_WORKSPACE/trusted/requirements-paperbot.lock" && \
                 ! -L "$GITHUB_WORKSPACE/trusted/requirements-paperbot.lock" && \
                 -f "$GITHUB_WORKSPACE/trusted/scripts/paperbot/pr_safety.py" && \
                 ! -L "$GITHUB_WORKSPACE/trusted/scripts/paperbot/pr_safety.py" ]]; then
-            echo "lock=trusted/requirements-paperbot.lock" >> "$GITHUB_OUTPUT"
+            if [[ "$LOCK_CHANGED" == "true" ]]; then
+              if [[ ! -f "$GITHUB_WORKSPACE/candidate/requirements-paperbot.lock" || \
+                    -L "$GITHUB_WORKSPACE/candidate/requirements-paperbot.lock" ]]; then
+                echo "::error::Candidate dependency lock must be a regular, non-symlink file"
+                exit 1
+              fi
+              echo "lock=candidate/requirements-paperbot.lock" >> "$GITHUB_OUTPUT"
+            else
+              echo "lock=trusted/requirements-paperbot.lock" >> "$GITHUB_OUTPUT"
+            fi
             echo "bootstrap=false" >> "$GITHUB_OUTPUT"
           else
             if [[ ! -f "$GITHUB_WORKSPACE/candidate/requirements-paperbot.lock" || \
@@ -131,7 +223,20 @@ jobs:
 
       - name: Run candidate paperbot tests
         working-directory: candidate
-        run: python -m pytest tests/paperbot
+        run: >-
+          env -u PYTHONPATH python -P -c
+          'import pytest,sys; sys.path.insert(0, ".");
+          raise SystemExit(pytest.main(["tests/paperbot"]))'
+
+      - name: Verify model with trusted code under selected dependencies
+        if: steps.dependencies.outputs.bootstrap != 'true'
+        working-directory: trusted
+        env:
+          PYTHONPATH: ${{ github.workspace }}/trusted
+        run: >-
+          python -m scripts.paperbot
+          --repo-root "$GITHUB_WORKSPACE/candidate"
+          check-model
 
       - name: Verify initial candidate model and policy
         if: steps.dependencies.outputs.bootstrap == 'true'
@@ -141,14 +246,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pytest tests/paperbot/test_no_remote_summarization.py
+          env -u PYTHONPATH python -P -c \
+            'import pytest,sys; sys.path.insert(0, "."); raise SystemExit(pytest.main(["tests/paperbot/test_no_remote_summarization.py"]))'
           python -m scripts.paperbot \
             --repo-root "$GITHUB_WORKSPACE/candidate" \
             check-model
 
   paperbot_test_gate:
     name: Test paperbot without credentials
-    needs: [detect_paperbot_changes, paperbot_tests]
+    needs: [detect_paperbot_changes, paperbot_tests, refresh-or-verify]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -159,6 +265,7 @@ jobs:
           DETECT_RESULT: ${{ needs.detect_paperbot_changes.result }}
           RELEVANT: ${{ needs.detect_paperbot_changes.outputs.relevant }}
           TEST_RESULT: ${{ needs.paperbot_tests.result }}
+          REFRESH_RESULT: ${{ needs.refresh-or-verify.result }}
         shell: bash
         run: |
           set -euo pipefail
@@ -168,6 +275,10 @@ jobs:
           fi
           if [[ "$RELEVANT" == "true" && "$TEST_RESULT" != "success" ]]; then
             echo "::error::The complete paperbot unit-test suite must pass"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" && "$REFRESH_RESULT" != "success" ]]; then
+            echo "::error::The paperbot refresh-or-verify job must pass"
             exit 1
           fi
           if [[ "$RELEVANT" != "true" && "$RELEVANT" != "false" ]]; then
@@ -189,8 +300,8 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       TOKENIZERS_PARALLELISM: "false"
       PAPERBOT_CONTACT_EMAIL: ${{ vars.PAPERBOT_CONTACT_EMAIL }}
-      BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
       HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
       HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
     steps:
@@ -250,17 +361,24 @@ jobs:
           --index-url https://download.pytorch.org/whl/cpu
           "torch==2.13.0"
 
+      # Never install candidate-controlled packages in this job: later steps
+      # receive issue and model-update credentials. Lock changes are checked
+      # with trusted code in the separate credential-free test job above.
       - name: Install trusted pinned dependencies
         if: steps.trusted.outputs.available == 'true'
-        run: python -m pip install --requirement trusted/requirements-paperbot.lock
+        run: >-
+          python -m pip install
+          --requirement trusted/requirements-paperbot.lock
 
       - name: Enforce the no-remote-summarization policy with trusted code
         if: steps.trusted.outputs.available == 'true'
+        working-directory: trusted
         env:
           PAPERBOT_POLICY_ROOT: ${{ github.workspace }}/candidate
         run: >-
-          python -m pytest
-          trusted/tests/paperbot/test_no_remote_summarization.py
+          env -u PYTHONPATH python -P -c
+          'import pytest,sys; sys.path.insert(0, ".");
+          raise SystemExit(pytest.main(["tests/paperbot/test_no_remote_summarization.py"]))'
 
       - name: Classify the pull request
         if: steps.trusted.outputs.available == 'true'
@@ -272,7 +390,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git -C candidate fetch --no-tags --depth=1 \
+            git -C candidate fetch --no-tags \
               "https://github.com/$GITHUB_REPOSITORY.git" "$BASE_SHA"
           fi
           PYTHONPATH="$GITHUB_WORKSPACE/trusted" \
@@ -346,10 +464,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "$MODEL_UPDATE_TOKEN" ]]; then
-            echo "::error::MODEL_UPDATE_TOKEN is required for same-repository model refreshes"
-            exit 1
-          fi
           git -C candidate add -- \
             bibliography.bib \
             paper_relevance/abstract_provenance.jsonl \
@@ -365,6 +479,10 @@ jobs:
           if git -C candidate diff --cached --quiet; then
             echo "Model artifacts are already current."
             exit 0
+          fi
+          if [[ -z "$MODEL_UPDATE_TOKEN" ]]; then
+            echo "::error::MODEL_UPDATE_TOKEN is required to commit refreshed artifacts"
+            exit 1
           fi
           git -C candidate config user.name "github-actions[bot]"
           git -C candidate config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -382,10 +500,15 @@ jobs:
           steps.trusted.outputs.available == 'true' &&
           steps.safety.outputs.auto_refresh != 'true'
         env:
+          LOCK_CHANGED: ${{ needs.detect_paperbot_changes.outputs.lock_changed }}
           PYTHONPATH: ${{ github.workspace }}/trusted
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$LOCK_CHANGED" == "true" ]]; then
+            echo "The model was checked with trusted code under the candidate dependencies in the credential-free test job."
+            exit 0
+          fi
           if ! python -m scripts.paperbot --repo-root "$GITHUB_WORKSPACE/candidate" check-model; then
             echo "::error::Model artifacts are stale. Run: python -m scripts.paperbot backfill-bibliography && GITHUB_TOKEN=... python -m scripts.paperbot sync-issue-negatives && python -m scripts.paperbot refresh-model"
             exit 1

--- a/.github/workflows/paper-model-refresh.yml
+++ b/.github/workflows/paper-model-refresh.yml
@@ -3,14 +3,6 @@ name: Refresh paper relevance model
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - bibliography.bib
-      - paper_relevance/**
-      - paperbot.toml
-      - requirements-paperbot.lock
-      - scripts/paperbot/**
-      - .github/workflows/paper-discovery.yml
-      - .github/workflows/paper-model-refresh.yml
   workflow_dispatch:
 
 permissions:
@@ -21,8 +13,64 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  paperbot-tests:
-    name: Test paperbot without credentials
+  detect_paperbot_changes:
+    name: Detect paperbot-relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.changes.outputs.relevant }}
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Check out candidate history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect relevant paths
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git -C candidate fetch --no-tags --depth=1 \
+            "https://github.com/$GITHUB_REPOSITORY.git" "$BASE_SHA"
+          if git -C candidate diff --quiet --no-renames \
+            "$BASE_SHA...$HEAD_SHA" -- \
+            bibliography.bib \
+            paperbot.toml \
+            requirements-paperbot.lock \
+            conftest.py \
+            pytest.ini \
+            pyproject.toml \
+            setup.cfg \
+            .gitattributes \
+            .lfsconfig \
+            ':(glob)**/.gitattributes' \
+            ':(glob)**/conftest.py' \
+            ':(glob)paper_relevance/**' \
+            ':(glob)scripts/**' \
+            ':(glob)tests/paperbot/**' \
+            .github/workflows/paper-discovery.yml \
+            .github/workflows/paper-model-refresh.yml; then
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  paperbot_tests:
+    name: Run paperbot unit tests
+    needs: detect_paperbot_changes
+    if: needs.detect_paperbot_changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,8 +146,39 @@ jobs:
             --repo-root "$GITHUB_WORKSPACE/candidate" \
             check-model
 
+  paperbot_test_gate:
+    name: Test paperbot without credentials
+    needs: [detect_paperbot_changes, paperbot_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require relevant paperbot tests
+        env:
+          DETECT_RESULT: ${{ needs.detect_paperbot_changes.result }}
+          RELEVANT: ${{ needs.detect_paperbot_changes.outputs.relevant }}
+          TEST_RESULT: ${{ needs.paperbot_tests.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$DETECT_RESULT" != "success" ]]; then
+            echo "::error::Could not determine whether paperbot tests are required"
+            exit 1
+          fi
+          if [[ "$RELEVANT" == "true" && "$TEST_RESULT" != "success" ]]; then
+            echo "::error::The complete paperbot unit-test suite must pass"
+            exit 1
+          fi
+          if [[ "$RELEVANT" != "true" && "$RELEVANT" != "false" ]]; then
+            echo "::error::Paperbot change detection returned an invalid result"
+            exit 1
+          fi
+
   refresh-or-verify:
     name: Refresh trusted PRs or verify artifacts
+    needs: detect_paperbot_changes
+    if: needs.detect_paperbot_changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
@@ -291,7 +370,12 @@ jobs:
           git -C candidate config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git -C candidate commit -m "chore: refresh paper relevance model"
           gh auth setup-git
-          git -C candidate push "https://github.com/$HEAD_REPOSITORY.git" "HEAD:$HEAD_REF"
+          # The explicit lease prevents a stale run from recreating a deleted
+          # PR branch or writing after its head has moved.
+          git -C candidate push \
+            --force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA" \
+            "https://github.com/$HEAD_REPOSITORY.git" \
+            "HEAD:refs/heads/$HEAD_REF"
 
       - name: Verify only (fork, manual, or sensitive change)
         if: >-

--- a/.github/workflows/paper-model-refresh.yml
+++ b/.github/workflows/paper-model-refresh.yml
@@ -102,6 +102,9 @@ jobs:
     name: Refresh trusted PRs or verify artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    permissions:
+      contents: read
+      issues: read
     env:
       HF_HUB_DISABLE_TELEMETRY: "1"
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
@@ -202,7 +205,7 @@ jobs:
               --same-repository "$SAME_REPOSITORY" \
               --github-output "$GITHUB_OUTPUT"
 
-      - name: Backfill abstracts and refresh model
+      - name: Backfill bibliography abstracts
         if: >-
           steps.trusted.outputs.available == 'true' &&
           steps.safety.outputs.auto_refresh == 'true'
@@ -219,6 +222,28 @@ jobs:
             exit 1
           fi
           python -m scripts.paperbot --repo-root "$GITHUB_WORKSPACE/candidate" backfill-bibliography
+
+      - name: Synchronize closed negative issues
+        if: >-
+          steps.trusted.outputs.available == 'true' &&
+          steps.safety.outputs.auto_refresh == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}/trusted
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.paperbot
+          --repo-root "$GITHUB_WORKSPACE/candidate"
+          sync-issue-negatives
+
+      - name: Refresh and verify model
+        if: >-
+          steps.trusted.outputs.available == 'true' &&
+          steps.safety.outputs.auto_refresh == 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}/trusted
+        shell: bash
+        run: |
+          set -euo pipefail
           python -m scripts.paperbot --repo-root "$GITHUB_WORKSPACE/candidate" refresh-model
           python -m scripts.paperbot --repo-root "$GITHUB_WORKSPACE/candidate" check-model
 
@@ -253,6 +278,9 @@ jobs:
             paper_relevance/positive_manifest.jsonl \
             paper_relevance/negative_embeddings.npy \
             paper_relevance/negative_manifest.jsonl \
+            paper_relevance/issue_negatives.jsonl \
+            paper_relevance/issue_negative_embeddings.npy \
+            paper_relevance/issue_negative_manifest.jsonl \
             paper_relevance/classifier.npz \
             paper_relevance/model_manifest.json
           if git -C candidate diff --cached --quiet; then
@@ -275,6 +303,6 @@ jobs:
         run: |
           set -euo pipefail
           if ! python -m scripts.paperbot --repo-root "$GITHUB_WORKSPACE/candidate" check-model; then
-            echo "::error::Model artifacts are stale. Run: python -m scripts.paperbot backfill-bibliography && python -m scripts.paperbot refresh-model"
+            echo "::error::Model artifacts are stale. Run: python -m scripts.paperbot backfill-bibliography && GITHUB_TOKEN=... python -m scripts.paperbot sync-issue-negatives && python -m scripts.paperbot refresh-model"
             exit 1
           fi

--- a/paper_relevance/README.md
+++ b/paper_relevance/README.md
@@ -63,6 +63,8 @@ operation, not part of ordinary bibliography refreshes.
 `sync-issue-negatives` uses GitHub's paginated Issues API and requires
 `GITHUB_TOKEN` with read-only issue access. The trusted bibliography refresh
 workflow runs it after abstract backfill and before model fitting.
+`refresh-model` refuses to invent an empty feedback snapshot, so a successful
+`sync-issue-negatives` run is required even when no issues currently qualify.
 Manual dispatch of that workflow is intentionally verification-only: automatic
 regeneration and bot pushes are limited to same-repository pull requests whose
 diff includes `bibliography.bib` and no sensitive generator or model changes.

--- a/paper_relevance/README.md
+++ b/paper_relevance/README.md
@@ -63,6 +63,9 @@ operation, not part of ordinary bibliography refreshes.
 `sync-issue-negatives` uses GitHub's paginated Issues API and requires
 `GITHUB_TOKEN` with read-only issue access. The trusted bibliography refresh
 workflow runs it after abstract backfill and before model fitting.
+Manual dispatch of that workflow is intentionally verification-only: automatic
+regeneration and bot pushes are limited to same-repository pull requests whose
+diff includes `bibliography.bib` and no sensitive generator or model changes.
 
 Before fitting, issue-derived works are canonicalized against both the frozen
 negative corpus and `bibliography.bib`. A duplicate fixed negative receives no

--- a/paper_relevance/README.md
+++ b/paper_relevance/README.md
@@ -6,10 +6,11 @@ deterministic logistic-regression head. SPECTER2's encoder weights are pinned in
 `paperbot.toml`, downloaded at runtime, and cached by GitHub Actions rather than
 stored in Git.
 
-The two float32 matrices contain one 768-dimensional row for every active
-bibliography work and every frozen negative. With roughly balanced classes,
-the vector data remains about 4 MiB and the complete artifact directory remains
-small enough that Git LFS is not needed.
+The float32 matrices contain one 768-dimensional row for every active
+bibliography work, every frozen negative, and every unique issue-derived
+negative encountered over time. Inactive issue rows are retained for audit and
+cheap reactivation. The vector data remains small enough that Git LFS is not
+needed.
 
 The classifier output is a ranking-oriented relevance score, not a calibrated
 probability. New issues use the strict configurable cutoff `score > 0.80`.
@@ -32,6 +33,18 @@ Generated files:
   PubMed query provenance, graph-policy version, aggregate graph coverage, and
   rejection counts for the frozen corpus. Generation stops unless at least 60%
   of canonical positive works resolve with usable reference lists.
+- `issue_negatives.jsonl`: a deterministic snapshot of closed,
+  paperbot-managed GitHub issues carrying the case-insensitive `negative`
+  label. Closing an issue without that label does not make it a negative, and
+  open or reopened issues are inactive. Each canonical work contributes at
+  most once even when duplicate issues, identifier aliases, revisions, or a
+  preprint/publication pair refer to it. The snapshot retains all contributing
+  issue numbers as provenance.
+- `issue_negative_embeddings.npy` and `issue_negative_manifest.jsonl`:
+  append-only SPECTER2 rows for issue-derived negatives and their active state.
+  Removing the label or reopening an issue deactivates its row on the next
+  synchronization; reclosing and relabeling an unchanged paper reuses the
+  existing embedding.
 - `abstract_provenance.jsonl`: source, retrieval date, text hash, and reported
   licence for every resolved bibliography abstract.
 - `abstract_exceptions.json`: reviewed, reasoned title-only exceptions for works
@@ -44,7 +57,18 @@ Network-backed regeneration requires Python 3.12 and the dependencies in
 `requirements-paperbot.lock`.
 
 The stable commands are `backfill-bibliography`, `bootstrap-negatives`,
-`refresh-model`, `check-model`, and `daily`. `bootstrap-negatives` is a
-network-backed, deliberate corpus-versioning operation, not part of ordinary
-bibliography refreshes. Run any command as
-`python -m scripts.paperbot <command> --help` for its narrow options.
+`sync-issue-negatives`, `refresh-model`, `check-model`, and `daily`.
+`bootstrap-negatives` is a network-backed, deliberate corpus-versioning
+operation, not part of ordinary bibliography refreshes.
+`sync-issue-negatives` uses GitHub's paginated Issues API and requires
+`GITHUB_TOKEN` with read-only issue access. The trusted bibliography refresh
+workflow runs it after abstract backfill and before model fitting.
+
+Before fitting, issue-derived works are canonicalized against both the frozen
+negative corpus and `bibliography.bib`. A duplicate fixed negative receives no
+extra training weight. A negative issue matching any canonical bibliography
+work is recorded as omitted and does not enter logistic-regression training;
+the bibliography remains authoritative for the positive class.
+
+Run any command as `python -m scripts.paperbot <command> --help` for its narrow
+options.

--- a/paper_relevance/SETUP.md
+++ b/paper_relevance/SETUP.md
@@ -15,7 +15,13 @@ For the issue-only reading queue:
    label, and open or reopened issues, do not become negative training examples.
 4. Require the **Test paperbot without credentials** status check in the
    `main` branch-protection rule. The check runs the complete paperbot suite for
-   relevant PRs and a lightweight fail-closed gate for unrelated PRs.
+   relevant PRs, also requires model refresh/verification to succeed, and uses
+   a lightweight fail-closed gate for unrelated PRs. Keep **Require branches to
+   be up to date before merging** enabled so the tested head cannot lag `main`.
+   Keep code-owner review enabled: stored embeddings can be checked for
+   consistency and deterministic refitting, but only the paperbot maintainer
+   can attest that a direct artifact change came from the pinned SPECTER2
+   generator rather than fabricated vectors.
 
 The daily schedule then runs at 00:00 UTC. A manual run defaults to dry-run mode,
 and a scheduled or explicitly non-dry manual run creates issues above the
@@ -85,6 +91,7 @@ policy, and seed in the trusted generator. Then run:
 ```sh
 SEMANTIC_SCHOLAR_API_KEY=... \
   python -m scripts.paperbot bootstrap-negatives --overwrite
+GITHUB_TOKEN=... python -m scripts.paperbot sync-issue-negatives
 python -m scripts.paperbot refresh-model --allow-negative-change
 python -m scripts.paperbot check-model
 ```

--- a/paper_relevance/SETUP.md
+++ b/paper_relevance/SETUP.md
@@ -10,6 +10,12 @@ For the issue-only reading queue:
 1. Merge the workflow and paperbot files into the default branch.
 2. Optionally add `PAPERBOT_CONTACT_EMAIL=<API contact address>` and the
    `NCBI_API_KEY` secret. The key only raises NCBI's request-rate allowance.
+3. Create a repository label named `negative`. To mark a paper as irrelevant,
+   apply that label and close its paperbot issue. Closed issues without the
+   label, and open or reopened issues, do not become negative training examples.
+4. Require the **Test paperbot without credentials** status check in the
+   `main` branch-protection rule. The check runs the complete paperbot suite for
+   relevant PRs and a lightweight fail-closed gate for unrelated PRs.
 
 The daily schedule then runs at 00:00 UTC. A manual run defaults to dry-run mode,
 and a scheduled or explicitly non-dry manual run creates issues above the
@@ -39,6 +45,10 @@ ranked queue:
 `MODEL_UPDATE_TOKEN` is separate and is needed only if the optional trusted-PR
 workflow should commit refreshed bibliography/model artifacts back to a branch.
 It should be a fine-grained token limited to SKM Contents read/write.
+Only configure it when every account and automation allowed to push branches
+inside SKM is trusted: GitHub makes repository secrets available to
+same-repository pull-request workflows. Fork pull requests remain verify-only
+and receive neither this token nor the NCBI key.
 
 Abstracts copied into this public repository retain their source rights. See
 `NOTICE.md` before changing the abstract-storage policy.

--- a/scripts/paperbot/backfill.py
+++ b/scripts/paperbot/backfill.py
@@ -12,13 +12,13 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from .bibliography import (
-  BibliographyEntry,
+  add_missing_abstracts,
   canonicalize_entries,
   load_bibliography,
   load_title_only_exceptions,
   missing_abstracts,
   normalize_abstract,
-  render_bibtex,
+  parse_bibtex,
 )
 from .config import PaperbotConfig
 from .enrichment import AbstractResolver, ResolvedAbstract
@@ -83,6 +83,7 @@ def backfill_bibliography(
   """
 
   entries = load_bibliography(config.bibliography_path)
+  _require_unique_citation_keys(entries)
   works = canonicalize_entries(entries)
   resolver = resolver or AbstractResolver(contact_email=config.contact_email)
   exceptions = load_title_only_exceptions(config.abstract_exceptions_path)
@@ -96,6 +97,7 @@ def backfill_bibliography(
   aliases_filled = 0
   for work in works:
     resolved: ResolvedAbstract | None
+    fetched = False
     reported_license = (
       work.fields.get("license", "").strip()
       or work.fields.get("copyright", "").strip()
@@ -118,12 +120,15 @@ def backfill_bibliography(
       resolved = None
     else:
       resolved = resolver.resolve(work.fields)
-      if resolved:
-        fetched_count += 1
+      fetched = resolved is not None
     if not resolved or not resolved.text:
       continue
 
     abstract = normalize_abstract(resolved.text)
+    if not abstract:
+      continue
+    if fetched:
+      fetched_count += 1
     for alias in work.aliases:
       abstracts[alias] = abstract
     aliases_filled += sum(
@@ -131,7 +136,18 @@ def backfill_bibliography(
       for entry in entries
       if entry.key in work.aliases and not normalize_abstract(entry.fields.get("abstract", ""))
     )
-    previous = old_provenance.get(work.work_id, {})
+    previous = (
+      old_provenance.get(work.work_id)
+      or old_provenance.get(work.citekey)
+      or next(
+        (
+          old_provenance[alias]
+          for alias in work.aliases
+          if alias in old_provenance
+        ),
+        {},
+      )
+    )
     source = resolved.source
     source_url = resolved.source_url
     license_value = resolved.license
@@ -155,20 +171,18 @@ def backfill_bibliography(
       }
     )
 
-  updated_entries = [
-    BibliographyEntry(
-      entry.entry_type,
-      entry.key,
-      {
-        **entry.fields,
-        **({"abstract": abstracts[entry.key]} if entry.key in abstracts else {}),
-      },
-    )
+  additions = {
+    entry.key: abstracts[entry.key]
     for entry in entries
-  ]
+    if entry.key in abstracts
+    and not normalize_abstract(entry.fields.get("abstract", ""))
+  }
+  new_text = add_missing_abstracts(old_text, additions)
+  updated_entries = parse_bibtex(new_text)
+  if [entry.key for entry in updated_entries] != [entry.key for entry in entries]:
+    raise ValueError("Abstract insertion changed the parsed BibTeX entry sequence")
   updated_works = canonicalize_entries(updated_entries)
   unresolved = tuple(work.citekey for work in missing_abstracts(updated_works, exceptions))
-  new_text = render_bibtex(updated_entries)
   changed = new_text != old_text
 
   if not dry_run:
@@ -184,6 +198,21 @@ def backfill_bibliography(
     unresolved=unresolved,
     changed=changed,
   )
+
+
+def _require_unique_citation_keys(entries: list[Any]) -> None:
+  owners: dict[str, str] = {}
+  duplicates: set[str] = set()
+  for entry in entries:
+    normalized = entry.key.casefold()
+    previous = owners.get(normalized)
+    if previous is None:
+      owners[normalized] = entry.key
+    else:
+      duplicates.update((previous, entry.key))
+  if duplicates:
+    labels = ", ".join(sorted(duplicates, key=str.casefold))
+    raise ValueError(f"Duplicate BibTeX citation keys are not allowed: {labels}")
 
 
 def _sha256(value: str) -> str:

--- a/scripts/paperbot/bibliography.py
+++ b/scripts/paperbot/bibliography.py
@@ -74,6 +74,8 @@ ABSTRACT_TRAILER_RE = re.compile(
   r"\s+(?:competing interests?|conflicts? of interests?|author disclosures?)\s*[:.]\s*.*$",
   re.IGNORECASE | re.DOTALL,
 )
+ENTRY_START_RE = re.compile(r"@(\w+)\s*([({])", re.IGNORECASE)
+CITATION_KEY_RE = re.compile(r"""[^\s\\#%"'(),={}]+""")
 
 
 @dataclass(frozen=True)
@@ -126,11 +128,30 @@ class AbstractCompletenessError(ValueError):
     super().__init__(f"Missing abstracts for {len(self.missing)} canonical works: {labels}")
 
 
+@dataclass(frozen=True)
+class _EntryBlock:
+  entry_type: str
+  start: int
+  body_start: int
+  body_end: int
+  end: int
+  opener: str
+  closer: str
+
+
 def _unescape_bibtex(value: str) -> str:
   # Do not attempt a lossy general LaTeX conversion.  These substitutions only
   # remove braces used to preserve capitalization and common escaped symbols.
+  literal_open = "\ue000"
+  literal_close = "\ue001"
+  value = value.replace(r"\{", literal_open).replace(r"\}", literal_close)
   value = value.replace(r"\&", "&").replace(r"\_", "_").replace(r"\%", "%")
-  return value.replace("{", "").replace("}", "")
+  return (
+    value.replace("{", "")
+    .replace("}", "")
+    .replace(literal_open, "{")
+    .replace(literal_close, "}")
+  )
 
 
 def normalize_abstract(value: str) -> str:
@@ -138,7 +159,7 @@ def normalize_abstract(value: str) -> str:
 
   if not value:
     return ""
-  value = _unescape_percent(value)
+  value = _decode_abstract_escapes(value)
   value = re.sub(r"(?is)<script.*?>.*?</script>|<style.*?>.*?</style>", " ", value)
   value = re.sub(r"(?s)<[^>]+>", " ", value)
   value = html.unescape(value)
@@ -146,6 +167,47 @@ def normalize_abstract(value: str) -> str:
   value = re.sub(r"\s+", " ", value).strip()
   value = ABSTRACT_TRAILER_RE.sub("", value).strip()
   return value
+
+
+def _decode_abstract_escapes(value: str) -> str:
+  """Decode only escapes emitted by ``_escape_inserted_abstract``.
+
+  Interpret escape parity from the original source. Decoding one marker must
+  not change whether an adjacent brace or percent escape is active.
+  """
+
+  marker = r"\textbackslash{}"
+  output: list[str] = []
+  index = 0
+  while index < len(value):
+    if (
+      value.startswith(marker, index)
+      and _is_active_backslash(value, index)
+    ):
+      output.append("\\")
+      index += len(marker)
+      continue
+    if (
+      value[index] == "\\"
+      and index + 1 < len(value)
+      and value[index + 1] in "{}%"
+      and _is_active_backslash(value, index)
+    ):
+      output.append(value[index + 1])
+      index += 2
+      continue
+    output.append(value[index])
+    index += 1
+  return "".join(output)
+
+
+def _is_active_backslash(value: str, index: int) -> bool:
+  preceding = 0
+  for char in reversed(value[:index]):
+    if char != "\\":
+      break
+    preceding += 1
+  return preceding % 2 == 0
 
 
 def normalize_doi(value: str) -> str:
@@ -193,30 +255,127 @@ def parse_bibtex(text: str) -> list[BibliographyEntry]:
   """Parse ordinary braced/quoted BibTeX entries while preserving all fields."""
 
   entries: list[BibliographyEntry] = []
-  cursor = 0
-  while True:
-    match = re.search(r"@(\w+)\s*([({])", text[cursor:], re.IGNORECASE)
-    if not match:
-      break
-    entry_type = match.group(1).lower()
-    open_delimiter = match.group(2)
-    close_delimiter = "}" if open_delimiter == "{" else ")"
-    body_start = cursor + match.end()
-    end = _balanced_end(
-      text, body_start, open_delimiter, close_delimiter, honor_top_level_quotes=True
-    )
-    body = text[body_start:end]
-    cursor = end + 1
-    if entry_type in {"comment", "preamble", "string"}:
+  for block in _entry_blocks(text):
+    body = text[block.body_start : block.body_end]
+    if block.entry_type in {"comment", "preamble", "string"}:
       continue
     comma = _top_level_comma(body)
     if comma < 0:
-      continue
+      raise ValueError(
+        f"Malformed @{block.entry_type} entry: missing citation-key separator"
+      )
     key = body[:comma].strip()
     if not key:
-      continue
-    entries.append(BibliographyEntry(entry_type, key, _parse_fields(body[comma + 1 :])))
+      raise ValueError(
+        f"Malformed @{block.entry_type} entry: empty citation key"
+      )
+    if CITATION_KEY_RE.fullmatch(key) is None:
+      raise ValueError(
+        f"Malformed @{block.entry_type} entry: invalid citation key {key!r}"
+      )
+    entries.append(
+      BibliographyEntry(
+        block.entry_type,
+        key,
+        _parse_fields(body[comma + 1 :]),
+      )
+    )
   return entries
+
+
+def _entry_blocks(text: str) -> Iterable[_EntryBlock]:
+  """Yield complete BibTeX directives without interpreting their contents."""
+
+  cursor = 0
+  while match := _next_entry_start(text, cursor):
+    opener = match.group(2)
+    closer = "}" if opener == "{" else ")"
+    body_start = match.end()
+    body_end = _entry_end(text, body_start, opener)
+    yield _EntryBlock(
+      entry_type=match.group(1).lower(),
+      start=match.start(),
+      body_start=body_start,
+      body_end=body_end,
+      end=body_end + 1,
+      opener=opener,
+      closer=closer,
+    )
+    cursor = body_end + 1
+
+
+def _next_entry_start(text: str, cursor: int) -> re.Match[str] | None:
+  for match in ENTRY_START_RE.finditer(text, cursor):
+    line_start = max(text.rfind("\n", 0, match.start()), text.rfind("\r", 0, match.start())) + 1
+    prefix = text[line_start : match.start()]
+    for index, char in enumerate(prefix):
+      if char != "%":
+        continue
+      backslashes = 0
+      for previous in reversed(prefix[:index]):
+        if previous != "\\":
+          break
+        backslashes += 1
+      if backslashes % 2 == 0:
+        break
+    else:
+      return match
+  return None
+
+
+def _entry_end(text: str, start: int, opener: str) -> int:
+  """Find an entry's closing delimiter while respecting values and comments."""
+
+  outer_depth = 1
+  brace_depth = 0
+  quoted = False
+  escaped = False
+  commented = False
+  for index in range(start, len(text)):
+    char = text[index]
+    if commented:
+      if char in "\r\n":
+        commented = False
+      continue
+    if escaped:
+      escaped = False
+      continue
+    if char == "\\":
+      escaped = True
+      continue
+    if char == "%" and not quoted:
+      commented = True
+      continue
+    if opener == "{":
+      if char == '"' and outer_depth == 1:
+        quoted = not quoted
+        continue
+      if quoted:
+        continue
+      if char == "{":
+        outer_depth += 1
+      elif char == "}":
+        outer_depth -= 1
+        if outer_depth == 0:
+          return index
+      continue
+
+    if char == '"' and brace_depth == 0:
+      quoted = not quoted
+      continue
+    if quoted:
+      continue
+    if char == "{":
+      brace_depth += 1
+    elif char == "}" and brace_depth:
+      brace_depth -= 1
+    elif brace_depth == 0 and char == "(":
+      outer_depth += 1
+    elif brace_depth == 0 and char == ")":
+      outer_depth -= 1
+      if outer_depth == 0:
+        return index
+  raise ValueError("Unterminated BibTeX entry")
 
 
 def _balanced_end(
@@ -230,8 +389,13 @@ def _balanced_end(
   depth = 1
   quoted = False
   escaped = False
+  commented = False
   for index in range(start, len(text)):
     char = text[index]
+    if commented:
+      if char in "\r\n":
+        commented = False
+      continue
     if escaped:
       escaped = False
       continue
@@ -243,6 +407,9 @@ def _balanced_end(
     # all quotes are ordinary text.
     if char == '"' and honor_top_level_quotes and depth == 1:
       quoted = not quoted
+      continue
+    if char == "%" and not quoted:
+      commented = True
       continue
     if quoted:
       continue
@@ -259,11 +426,18 @@ def _top_level_comma(value: str) -> int:
   brace_depth = 0
   quoted = False
   escaped = False
+  commented = False
   for index, char in enumerate(value):
+    if commented:
+      if char in "\r\n":
+        commented = False
+      continue
     if escaped:
       escaped = False
     elif char == "\\":
       escaped = True
+    elif char == "%" and not quoted:
+      commented = True
     elif char == '"' and brace_depth == 0:
       quoted = not quoted
     elif not quoted and char == "{":
@@ -277,31 +451,93 @@ def _top_level_comma(value: str) -> int:
 
 def _parse_fields(body: str) -> dict[str, str]:
   fields: dict[str, str] = {}
-  index = 0
-  while index < len(body):
-    while index < len(body) and (body[index].isspace() or body[index] == ","):
-      index += 1
-    name_match = re.match(r"[A-Za-z][A-Za-z0-9_-]*", body[index:])
-    if not name_match:
-      break
-    name = name_match.group(0).lower()
-    index += name_match.end()
-    while index < len(body) and body[index].isspace():
-      index += 1
-    if index >= len(body) or body[index] != "=":
-      break
-    index += 1
-    while index < len(body) and body[index].isspace():
-      index += 1
-    value, index = _parse_field_value(body, index)
+  for name, value, _, _ in _field_values(body):
+    if name in fields:
+      raise ValueError(f"Duplicate BibTeX field: {name}")
     fields[name] = html.unescape(value.strip())
   return fields
 
 
+def _field_values(
+  body: str,
+) -> Iterable[tuple[str, str, int, int]]:
+  """Yield normalized field names, values, and exact value spans."""
+
+  index = 0
+  parsed_field = False
+  while index < len(body):
+    index = _skip_bibtex_spacing(body, index)
+    if index >= len(body):
+      break
+    if parsed_field:
+      if body[index] != ",":
+        raise ValueError("Malformed BibTeX fields: missing comma separator")
+      index = _skip_bibtex_spacing(body, index + 1)
+      if index >= len(body):
+        break
+    name_match = re.match(r"[A-Za-z][A-Za-z0-9_-]*", body[index:])
+    if not name_match:
+      excerpt = body[index : index + 40].splitlines()[0]
+      raise ValueError(f"Malformed BibTeX field near {excerpt!r}")
+    name = name_match.group(0).lower()
+    index += name_match.end()
+    index = _skip_bibtex_spacing(body, index)
+    if index >= len(body) or body[index] != "=":
+      raise ValueError(f"Malformed BibTeX field {name!r}: missing '='")
+    index += 1
+    index = _skip_bibtex_spacing(body, index)
+    value_start = index
+    value, index = _parse_field_value(body, index)
+    yield name, value, value_start, index
+    parsed_field = True
+
+
+def _skip_bibtex_spacing(
+  body: str,
+  index: int,
+  *,
+  commas: bool = False,
+) -> int:
+  """Skip syntactic whitespace and TeX comments between BibTeX tokens."""
+
+  while index < len(body):
+    if body[index].isspace() or (commas and body[index] == ","):
+      index += 1
+      continue
+    if body[index] == "%":
+      newline = min(
+        (
+          position
+          for marker in ("\n", "\r")
+          if (position := body.find(marker, index + 1)) >= 0
+        ),
+        default=len(body),
+      )
+      index = newline
+      continue
+    return index
+  return index
+
+
 def _parse_field_value(body: str, index: int) -> tuple[str, int]:
+  values: list[str] = []
+  while True:
+    value, index = _parse_field_atom(body, index)
+    values.append(value)
+    value_end = index
+    separator = _skip_bibtex_spacing(body, index)
+    if separator >= len(body) or body[separator] != "#":
+      return "".join(values), value_end
+    index = separator + 1
+    index = _skip_bibtex_spacing(body, index)
+
+
+def _parse_field_atom(body: str, index: int) -> tuple[str, int]:
   if index >= len(body):
-    return "", index
+    raise ValueError("Malformed BibTeX field: missing value")
   delimiter = body[index]
+  if delimiter in "#,\n\r":
+    raise ValueError("Malformed BibTeX field: missing value")
   if delimiter == "{":
     end = _balanced_end(body, index + 1, "{", "}")
     return body[index + 1 : end], end + 1
@@ -320,9 +556,140 @@ def _parse_field_value(body: str, index: int) -> tuple[str, int]:
       index += 1
     raise ValueError("Unterminated quoted BibTeX value")
   end = index
-  while end < len(body) and body[end] not in ",\n\r":
+  escaped = False
+  while end < len(body):
+    char = body[end]
+    if char in "#,\n\r" or (char == "%" and not escaped):
+      break
+    escaped = char == "\\" and not escaped
+    if char != "\\":
+      escaped = False
     end += 1
   return body[index:end].strip(), end
+
+
+def add_missing_abstracts(
+  text: str,
+  abstracts: Mapping[str, str],
+) -> str:
+  """Insert abstract fields while preserving every other source byte.
+
+  This intentionally does not render the parsed bibliography. BibTeX string
+  directives, comments, macro expressions, field order, and hand formatting
+  remain untouched.
+  """
+
+  if not abstracts:
+    return text
+  pending = dict(abstracts)
+  replacements: list[tuple[int, int, str]] = []
+  for block in _entry_blocks(text):
+    if block.entry_type in {"comment", "preamble", "string"}:
+      continue
+    body = text[block.body_start : block.body_end]
+    comma = _top_level_comma(body)
+    if comma < 0:
+      continue
+    key = body[:comma].strip()
+    abstract = pending.pop(key, None)
+    if abstract is None:
+      continue
+    replacement = _entry_with_abstract(text, block, abstract)
+    replacements.append((block.start, block.end, replacement))
+  if pending:
+    missing = ", ".join(sorted(pending))
+    raise ValueError(f"Could not locate BibTeX entries while adding abstracts: {missing}")
+  updated = text
+  for start, end, replacement in reversed(replacements):
+    updated = updated[:start] + replacement + updated[end:]
+  return updated
+
+
+def _entry_with_abstract(text: str, block: _EntryBlock, abstract: str) -> str:
+  entry = text[block.start : block.end]
+  body = text[block.body_start : block.body_end]
+  first_comma = _top_level_comma(body)
+  if first_comma < 0:
+    raise ValueError("Cannot add an abstract to a BibTeX entry without fields")
+  field_body = body[first_comma + 1 :]
+  abstract_fields = [
+    (value, start, end)
+    for name, value, start, end in _field_values(field_body)
+    if name == "abstract"
+  ]
+  if len(abstract_fields) > 1:
+    raise ValueError("BibTeX entry already contains duplicate abstract fields")
+  if abstract_fields:
+    value, start, end = abstract_fields[0]
+    if normalize_abstract(value):
+      raise ValueError("Refusing to replace a nonempty BibTeX abstract")
+    field_offset = block.body_start - block.start + first_comma + 1
+    value_start = field_offset + start
+    value_end = field_offset + end
+    replacement = "{" + _escape_inserted_abstract(abstract) + "}"
+    return entry[:value_start] + replacement + entry[value_end:]
+
+  closing_index = block.body_end - block.start
+  line_start = entry.rfind("\n", 0, closing_index) + 1
+  closing_prefix = entry[line_start:closing_index]
+  insert_at = line_start if not closing_prefix.strip() else closing_index
+  before = entry[:insert_at]
+  after = entry[insert_at:]
+  significant = _last_uncommented_nonspace(before)
+  if significant < 0:
+    raise ValueError("Cannot add an abstract to an empty BibTeX entry")
+  if before[significant] != ",":
+    before = before[: significant + 1] + "," + before[significant + 1 :]
+  if not before.endswith(("\n", "\r")):
+    before += "\n"
+  indent_match = re.search(
+    r"(?m)^([ \t]+)[A-Za-z][A-Za-z0-9_-]*\s*=",
+    text[block.body_start : block.body_end],
+  )
+  indent = indent_match.group(1) if indent_match else "  "
+  field = f"{indent}abstract = {{{_escape_inserted_abstract(abstract)}}},\n"
+  return before + field + after
+
+
+def _last_uncommented_nonspace(value: str) -> int:
+  """Return the last significant TeX character, ignoring percent comments."""
+
+  last = -1
+  escaped = False
+  commented = False
+  for index, char in enumerate(value):
+    if commented:
+      if char in "\r\n":
+        commented = False
+      continue
+    if escaped:
+      escaped = False
+      if not char.isspace():
+        last = index
+      continue
+    if char == "\\":
+      escaped = True
+      last = index
+    elif char == "%":
+      commented = True
+    elif not char.isspace():
+      last = index
+  return last
+
+
+def _escape_inserted_abstract(value: str) -> str:
+  """Encode plain text so provider punctuation cannot break a braced value."""
+
+  value = normalize_abstract(value)
+  # Encode each original character independently. This prevents an existing
+  # even-length backslash run from cancelling the escape on a following brace.
+  replacements = {
+    "\\": r"\textbackslash{}",
+    "{": r"\{",
+    "}": r"\}",
+    "%": r"\%",
+  }
+  return "".join(replacements.get(char, char) for char in value)
 
 
 def load_bibliography(path: Path | str) -> list[BibliographyEntry]:
@@ -610,7 +977,8 @@ def _merge_fields(entries: Sequence[BibliographyEntry]) -> dict[str, str]:
 def _choose_work_id(identifiers: Sequence[str], entries: Sequence[BibliographyEntry]) -> str:
   doi_candidates = sorted(
     identifier for identifier in identifiers
-    if identifier.startswith("doi:") and not identifier.startswith("doi:10.1101/")
+    if identifier.startswith("doi:")
+    and not identifier.startswith(PREPRINT_DOI_PREFIXES)
   )
   if doi_candidates:
     return doi_candidates[0]

--- a/scripts/paperbot/bibliography.py
+++ b/scripts/paperbot/bibliography.py
@@ -29,6 +29,10 @@ BARE_ARXIV_RE = re.compile(
   r"^(?:[a-z-]+(?:\.[A-Z]{2})?/\d{7}|\d{4}\.\d{4,5})(?:v\d+)?$",
   re.IGNORECASE,
 )
+CHEMRXIV_VERSION_RE = re.compile(
+  r"(?P<base>10\.26434/[^\s]+?)(?:-v|/v)\d+$",
+  re.IGNORECASE,
+)
 RELATION_FIELDS = {
   "relation",
   "related",
@@ -42,6 +46,13 @@ RELATION_FIELDS = {
   "publisheddoi",
   "published_doi",
 }
+PREPRINT_DOI_PREFIXES = (
+  "doi:10.1101/",  # bioRxiv and medRxiv
+  "doi:10.21203/rs.",  # Research Square
+  "doi:10.26434/",  # ChemRxiv
+  "doi:10.48550/arxiv.",
+  "doi:10.64898/",  # current bioRxiv and medRxiv DOI prefix
+)
 DEFAULT_FIELD_ORDER = (
   "title",
   "author",
@@ -145,6 +156,11 @@ def normalize_doi(value: str) -> str:
   value = value.rstrip(".,;:)]}").lower()
   # bioRxiv/medRxiv use one base DOI for all versions.
   value = re.sub(r"(10\.1101/[0-9.]+)v\d+$", r"\1", value, flags=re.IGNORECASE)
+  # ChemRxiv has used both ``-vN`` and ``/vN`` suffixes for versions of the
+  # same work. Match PaperRecord.canonical_id so bibliography versions cannot
+  # receive duplicate positive training weight.
+  if match := CHEMRXIV_VERSION_RE.fullmatch(value):
+    value = match.group("base")
   return value
 
 
@@ -405,15 +421,42 @@ def _preprint_match_identity(entry: BibliographyEntry) -> str:
 
 
 def _has_preprint_identifier(identifiers: set[str]) -> bool:
-  return any(identifier.startswith("arxiv:") or identifier.startswith("doi:10.1101/") for identifier in identifiers)
+  return any(
+    identifier.startswith("arxiv:")
+    or identifier.startswith(PREPRINT_DOI_PREFIXES)
+    for identifier in identifiers
+  )
 
 
 def _is_preprint_publication_pair(left: set[str], right: set[str]) -> bool:
   if not left or not right or left & right:
     return False
-  left_preprint = _has_preprint_identifier(left)
-  right_preprint = _has_preprint_identifier(right)
-  return left_preprint != right_preprint
+  return {_identifier_stage(left), _identifier_stage(right)} == {
+    "preprint",
+    "publication",
+  }
+
+
+def _identifier_stage(identifiers: set[str]) -> str:
+  """Classify one already-deduplicated identity component for safe bridging."""
+
+  has_preprint = _has_preprint_identifier(identifiers)
+  has_publication_doi = any(
+    identifier.startswith("doi:")
+    and not identifier.startswith(PREPRINT_DOI_PREFIXES)
+    for identifier in identifiers
+  )
+  if has_preprint and has_publication_doi:
+    return "mixed"
+  if has_preprint:
+    return "preprint"
+  # A PMID-only bibliography record is ordinarily the publication side of a
+  # preprint/publication pair. PMID is neutral when a preprint DOI is present.
+  if has_publication_doi or any(
+    identifier.startswith("pmid:") for identifier in identifiers
+  ):
+    return "publication"
+  return ""
 
 
 class _UnionFind:
@@ -448,29 +491,72 @@ def canonicalize_entries(entries: Sequence[BibliographyEntry]) -> list[Canonical
   # Link an arXiv/bioRxiv preprint to its version of record when the normalized
   # title and first author are exact.  Publication years commonly differ, so
   # this relation intentionally precedes the title/author/year fallback.
-  publication_owner: dict[str, int] = {}
+  publication_groups: dict[str, list[int]] = {}
   for index, entry in enumerate(entries):
     relation = _preprint_match_identity(entry)
     if not relation:
       continue
-    previous = publication_owner.get(relation)
-    if previous is None:
-      publication_owner[relation] = index
-    elif _is_preprint_publication_pair(identities_by_entry[index], identities_by_entry[previous]):
-      union.union(index, previous)
+    publication_groups.setdefault(relation, []).append(index)
+  publication_edges: set[tuple[int, int]] = set()
+  for indexes in publication_groups.values():
+    components = _component_identifiers(union, identities_by_entry, indexes)
+    identified = [
+      (root, identifiers)
+      for root, identifiers in components.items()
+      if identifiers
+    ]
+    # Exact title/author metadata can bridge one unambiguous preprint and one
+    # publication. With more identified components, choosing a publication
+    # would depend on input order and could collapse distinct strong IDs.
+    if (
+      len(identified) == 2
+      and _is_preprint_publication_pair(identified[0][1], identified[1][1])
+    ):
+      publication_edges.add(tuple(sorted((identified[0][0], identified[1][0]))))
+  publication_neighbors: dict[int, set[int]] = {}
+  for left, right in publication_edges:
+    publication_neighbors.setdefault(left, set()).add(right)
+    publication_neighbors.setdefault(right, set()).add(left)
+  for left, right in sorted(publication_edges):
+    # A preprint component can appear under multiple historical titles. Merge
+    # only one-to-one candidate edges so traversal/input order cannot choose
+    # arbitrarily among several plausible versions of record.
+    if (
+      len(publication_neighbors[left]) == 1
+      and len(publication_neighbors[right]) == 1
+    ):
+      union.union(left, right)
 
   # A title fallback can attach an identifier-less alias to an identified work,
   # but it must never merge two entries carrying conflicting strong identifiers.
-  fallback_owner: dict[str, int] = {}
+  fallback_groups: dict[str, list[int]] = {}
   for index, entry in enumerate(entries):
     fallback = fallback_identity(entry)
     if not fallback:
       continue
-    previous = fallback_owner.get(fallback)
-    if previous is None:
-      fallback_owner[fallback] = index
-    elif not identities_by_entry[index] or not identities_by_entry[previous] or identities_by_entry[index] & identities_by_entry[previous]:
-      union.union(index, previous)
+    fallback_groups.setdefault(fallback, []).append(index)
+  for indexes in fallback_groups.values():
+    components = _component_identifiers(union, identities_by_entry, indexes)
+    identified_roots = [
+      root for root, identifiers in components.items() if identifiers
+    ]
+    identifierless_roots = [
+      root for root, identifiers in components.items() if not identifiers
+    ]
+    if len(identified_roots) == 1:
+      destination = identified_roots[0]
+      for root in identifierless_roots:
+        union.union(destination, root)
+    elif not identified_roots and identifierless_roots:
+      destination, *duplicates = identifierless_roots
+      for root in duplicates:
+        union.union(destination, root)
+    elif len(identifierless_roots) > 1:
+      # Preserve duplicate identifier-less aliases as one unresolved work, but
+      # do not arbitrarily attach that work to one of several conflicting IDs.
+      destination, *duplicates = identifierless_roots
+      for root in duplicates:
+        union.union(destination, root)
 
   grouped: dict[int, list[int]] = {}
   for index in range(len(entries)):
@@ -486,6 +572,22 @@ def canonicalize_entries(entries: Sequence[BibliographyEntry]) -> list[Canonical
     entry_type = sorted(component, key=lambda entry: (-_entry_richness(entry), entry.key))[0].entry_type
     works.append(CanonicalWork(work_id, aliases[0], aliases, identifiers, entry_type, merged))
   return sorted(works, key=lambda work: (work.work_id, work.citekey))
+
+
+def _component_identifiers(
+  union: _UnionFind,
+  identities_by_entry: Sequence[set[str]],
+  indexes: Sequence[int],
+) -> dict[int, set[str]]:
+  """Return strong identifiers accumulated by each current union component."""
+
+  wanted_roots = {union.find(index) for index in indexes}
+  components = {root: set() for root in wanted_roots}
+  for index, identifiers in enumerate(identities_by_entry):
+    root = union.find(index)
+    if root in components:
+      components[root].update(identifiers)
+  return components
 
 
 def _entry_richness(entry: BibliographyEntry) -> int:

--- a/scripts/paperbot/cli.py
+++ b/scripts/paperbot/cli.py
@@ -114,7 +114,7 @@ def main(argv: Sequence[str] | None = None) -> int:
   elif not config_path.is_absolute():
     config_path = root / config_path
   try:
-    config = load_config(config_path)
+    config = load_config(config_path, repository_root=root)
     _validate_pins(config)
     if args.command == "backfill-bibliography":
       result = backfill_bibliography(config, dry_run=args.dry_run)

--- a/scripts/paperbot/cli.py
+++ b/scripts/paperbot/cli.py
@@ -68,6 +68,11 @@ def build_parser() -> argparse.ArgumentParser:
     ),
   )
 
+  subparsers.add_parser(
+    "sync-issue-negatives",
+    help="snapshot closed paperbot issues labeled negative for model training",
+  )
+
   refresh = subparsers.add_parser(
     "refresh-model", help="refresh changed embeddings and refit logistic regression"
   )
@@ -132,6 +137,18 @@ def main(argv: Sequence[str] | None = None) -> int:
           "metadata_path": str(config.negative_metadata_path),
         }
       )
+      return 0
+
+    if args.command == "sync-issue-negatives":
+      token = os.getenv("GITHUB_TOKEN", "")
+      if not token:
+        parser.error("GITHUB_TOKEN is required to synchronize issue negatives")
+      # Import lazily so offline commands and model checks do not load the
+      # network-backed issue collector.
+      from .issue_negatives import sync_issue_negatives
+
+      result = sync_issue_negatives(config, github_token=token)
+      _print_json(result)
       return 0
 
     if args.command == "refresh-model":

--- a/scripts/paperbot/config.py
+++ b/scripts/paperbot/config.py
@@ -56,6 +56,18 @@ class PaperbotConfig:
     return self.artifact_dir / "negative_manifest.jsonl"
 
   @property
+  def issue_negative_corpus_path(self) -> Path:
+    return self.artifact_dir / "issue_negatives.jsonl"
+
+  @property
+  def issue_negative_embeddings_path(self) -> Path:
+    return self.artifact_dir / "issue_negative_embeddings.npy"
+
+  @property
+  def issue_negative_manifest_path(self) -> Path:
+    return self.artifact_dir / "issue_negative_manifest.jsonl"
+
+  @property
   def classifier_path(self) -> Path:
     return self.artifact_dir / "classifier.npz"
 

--- a/scripts/paperbot/config.py
+++ b/scripts/paperbot/config.py
@@ -76,9 +76,22 @@ class PaperbotConfig:
     return self.artifact_dir / "model_manifest.json"
 
 
-def _path(value: str | Path, root: Path) -> Path:
-  path = Path(value)
-  return path if path.is_absolute() else root / path
+def _path(
+  value: str | Path,
+  root: Path,
+  *,
+  repository_root: Path | None = None,
+) -> Path:
+  try:
+    path = Path(value)
+  except TypeError as error:
+    raise ValueError("paperbot data paths must be strings") from error
+  resolved = (path if path.is_absolute() else root / path).resolve()
+  if repository_root is not None and not resolved.is_relative_to(repository_root):
+    raise ValueError(
+      f"paperbot data path escapes repository root {repository_root}: {value}"
+    )
+  return resolved
 
 
 def _section(raw: dict[str, Any], name: str) -> dict[str, Any]:
@@ -88,14 +101,31 @@ def _section(raw: dict[str, Any], name: str) -> dict[str, Any]:
   return value
 
 
-def load_config(path: Path | str = DEFAULT_CONFIG_PATH) -> PaperbotConfig:
-  config_path = Path(path)
+def load_config(
+  path: Path | str = DEFAULT_CONFIG_PATH,
+  *,
+  repository_root: Path | str | None = None,
+) -> PaperbotConfig:
+  requested_config_path = Path(path)
+  config_path = requested_config_path.resolve()
+  confined_root = Path(repository_root).resolve() if repository_root is not None else None
+  if confined_root is not None:
+    if not confined_root.is_dir():
+      raise ValueError(f"paperbot repository root is not a directory: {confined_root}")
+    if not config_path.is_relative_to(confined_root):
+      raise ValueError(
+        f"paperbot config must be inside repository root {confined_root}: {config_path}"
+      )
+    if requested_config_path.is_symlink() or not config_path.is_file():
+      raise ValueError(
+        f"paperbot config must be a regular, non-symlink file: {config_path}"
+      )
   raw: dict[str, Any] = {}
   if config_path.exists():
     with config_path.open("rb") as handle:
       raw = tomllib.load(handle)
 
-  root = config_path.resolve().parent if config_path.exists() else REPO_ROOT
+  root = config_path.parent
   project = _section(raw, "project")
   model = _section(raw, "model")
   discovery = _section(raw, "discovery")
@@ -111,10 +141,20 @@ def load_config(path: Path | str = DEFAULT_CONFIG_PATH) -> PaperbotConfig:
 
   return PaperbotConfig(
     repository=str(raw.get("repository", "delalamo/SKM")),
-    bibliography_path=_path(paths.get("bibliography", "bibliography.bib"), root),
-    artifact_dir=_path(paths.get("artifacts", "paper_relevance"), root),
+    bibliography_path=_path(
+      paths.get("bibliography", "bibliography.bib"),
+      root,
+      repository_root=confined_root,
+    ),
+    artifact_dir=_path(
+      paths.get("artifacts", "paper_relevance"),
+      root,
+      repository_root=confined_root,
+    ),
     abstract_exceptions_path=_path(
-      paths.get("abstract_exceptions", "paper_relevance/abstract_exceptions.json"), root
+      paths.get("abstract_exceptions", "paper_relevance/abstract_exceptions.json"),
+      root,
+      repository_root=confined_root,
     ),
     relevance_threshold=threshold,
     recovery_hours=int(discovery.get("recovery_hours", 72)),

--- a/scripts/paperbot/github.py
+++ b/scripts/paperbot/github.py
@@ -220,7 +220,12 @@ class GitHubClient:
 
     def list_issues(self, *, label: str | None = "paper") -> list[dict[str, Any]]:
         path = f"/repos/{self.repo}/issues"
-        params = {"state": "all"}
+        # Created-ascending order makes page-number pagination stable when new
+        # issues are opened while a long collection pass is in progress: new
+        # rows are appended after the pages already read instead of shifting
+        # their offsets. Label and state changes can still race a run, so
+        # callers that need a snapshot validate duplicate identities.
+        params = {"state": "all", "sort": "created", "direction": "asc"}
         if label:
             params["labels"] = label
         return [
@@ -471,6 +476,18 @@ def load_managed_issues(client: GitHubClient) -> ManagedIssueIndex:
         meta = parse_managed_meta(body)
         if meta is None:
             continue
+        blocks = list(_MANAGED_RE.finditer(body))
+        if (
+            len(blocks) != 1
+            or body.count(MANAGED_BLOCK_BEGIN) != 1
+            or body.count(MANAGED_BLOCK_END) != 1
+            or META_PREFIX not in blocks[0].group(0)
+        ):
+            number = raw.get("number", "?")
+            raise GitHubError(
+                f"Managed paper issue #{number} must contain exactly one "
+                "complete paperbot block"
+            )
         index.add(_managed_issue_from_api(raw, meta))
     return index
 
@@ -636,14 +653,25 @@ def rescore_managed_issues(
 
 
 def parse_managed_meta(body: str) -> dict[str, Any] | None:
-    match = _META_RE.search(body)
-    if not match:
+    matches = list(_META_RE.finditer(body))
+    if not matches:
+        if META_PREFIX in body:
+            raise GitHubError("Managed paper issue contains an incomplete metadata marker")
         return None
+    if len(matches) != 1 or body.count(META_PREFIX) != 1:
+        raise GitHubError("Managed paper issue must contain exactly one metadata marker")
+    match = matches[0]
     try:
         payload = json.loads(match.group(1))
     except json.JSONDecodeError as error:
         raise GitHubError("Managed paper issue contains invalid metadata JSON") from error
-    if not isinstance(payload, dict) or payload.get("schema") != 1:
+    schema = payload.get("schema") if isinstance(payload, dict) else None
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(schema, int)
+        or isinstance(schema, bool)
+        or schema != 1
+    ):
         raise GitHubError("Managed paper issue has an unsupported metadata schema")
     return payload
 
@@ -813,7 +841,11 @@ def identity_for_record(record: Any) -> tuple[str, list[str]]:
         aliases.add(f"{source}:{source_id.casefold()}")
     identity_aliases = getattr(record, "identity_aliases", None)
     if callable(identity_aliases):
-        aliases.update(normalize_alias(str(alias)) for alias in identity_aliases())
+        aliases.update(
+            normalized
+            for alias in identity_aliases()
+            if (normalized := normalize_alias(str(alias)))
+        )
     related = _value(record, "aliases", []) or []
     related_work = _value(record, "related_work_aliases", []) or []
     related_ids = _value(record, "related_ids", []) or []
@@ -824,8 +856,13 @@ def identity_for_record(record: Any) -> tuple[str, list[str]]:
     title_alias = title_identity_alias(record)
     if title_alias:
         aliases.add(title_alias)
-    ordered = sorted(aliases)
     canonical_id = normalize_alias(str(_value(record, "canonical_id", "") or ""))
+    if canonical_id:
+        # The collector requires the canonical work identity to be one of the
+        # hashed aliases. Keeping that invariant here prevents paperbot from
+        # creating an issue that its own training refresh later rejects.
+        aliases.add(canonical_id)
+    ordered = sorted(aliases)
     preferred = canonical_id or next(
         (
             prefix

--- a/scripts/paperbot/issue_negatives.py
+++ b/scripts/paperbot/issue_negatives.py
@@ -12,6 +12,7 @@ import tempfile
 from typing import Any, Iterable, Mapping, Sequence
 
 from .bibliography import (
+  BibliographyEntry,
   CanonicalWork,
   canonicalize_entries,
   embedding_input_hash,
@@ -88,6 +89,9 @@ class IssueNegativeRecord:
   omission_reasons: tuple[str, ...] = ()
   bibliography_keys: tuple[str, ...] = ()
   fixed_negative_ids: tuple[str, ...] = ()
+  known_bib_keys: tuple[str, ...] = ()
+  component_titles: tuple[str, ...] = ()
+  component_input_hashes: tuple[str, ...] = ()
 
   def to_dict(self) -> dict[str, Any]:
     return {
@@ -105,6 +109,9 @@ class IssueNegativeRecord:
       "omission_reasons": list(self.omission_reasons),
       "bibliography_keys": list(self.bibliography_keys),
       "fixed_negative_ids": list(self.fixed_negative_ids),
+      "known_bib_keys": list(self.known_bib_keys),
+      "component_titles": list(self.component_titles),
+      "component_input_hashes": list(self.component_input_hashes),
     }
 
   @classmethod
@@ -126,15 +133,36 @@ class IssueNegativeRecord:
     aliases_value = value.get("aliases")
     numbers_value = value.get("issue_numbers")
     urls_value = value.get("issue_urls")
-    title = str(value.get("title") or "").strip()
-    abstract = str(value.get("abstract") or "").strip()
-    input_hash = str(value.get("input_hash") or "").strip().casefold()
-    metadata_hash = str(value.get("metadata_hash") or "").strip().casefold()
+    title_value = value.get("title")
+    abstract_value = value.get("abstract")
+    input_hash_value = value.get("input_hash")
+    metadata_hash_value = value.get("metadata_hash")
+    if (
+      not isinstance(title_value, str)
+      or not isinstance(abstract_value, str)
+      or title_value != title_value.strip()
+      or abstract_value != abstract_value.strip()
+    ):
+      raise ValueError(f"{context} title and abstract must be canonical strings")
+    if (
+      not isinstance(input_hash_value, str)
+      or not isinstance(metadata_hash_value, str)
+      or input_hash_value != input_hash_value.strip().casefold()
+      or metadata_hash_value != metadata_hash_value.strip().casefold()
+    ):
+      raise ValueError(f"{context} hashes must be canonical strings")
+    title = title_value
+    abstract = abstract_value
+    input_hash = input_hash_value
+    metadata_hash = metadata_hash_value
     selected_issue_number = value.get("selected_issue_number")
     active = value.get("active")
     omission_reasons_value = value.get("omission_reasons")
     bibliography_keys_value = value.get("bibliography_keys")
     fixed_negative_ids_value = value.get("fixed_negative_ids")
+    known_bib_keys_value = value.get("known_bib_keys")
+    component_titles_value = value.get("component_titles")
+    component_input_hashes_value = value.get("component_input_hashes")
     if (
       not work_id
       or work_id != work_id_text
@@ -178,10 +206,13 @@ class IssueNegativeRecord:
     if (
       not isinstance(urls_value, list)
       or not urls_value
-      or any(not isinstance(url, str) or not url.strip() for url in urls_value)
+      or any(
+        not isinstance(url, str) or not url or url != url.strip()
+        for url in urls_value
+      )
     ):
       raise ValueError(f"{context} issue URLs are invalid")
-    issue_urls = tuple(str(url).strip() for url in urls_value)
+    issue_urls = tuple(urls_value)
     url_numbers = {
       int(match.group(1))
       for url in issue_urls
@@ -202,9 +233,12 @@ class IssueNegativeRecord:
       raise ValueError(f"{context} SPECTER2 input hash is invalid")
     if active is not True and active is not False:
       raise ValueError(f"{context} active flag is invalid")
-    if not isinstance(omission_reasons_value, list):
+    if (
+      not isinstance(omission_reasons_value, list)
+      or any(not isinstance(reason, str) for reason in omission_reasons_value)
+    ):
       raise ValueError(f"{context} omission reasons must be a list")
-    omission_reasons = tuple(str(reason) for reason in omission_reasons_value)
+    omission_reasons = tuple(omission_reasons_value)
     if (
       omission_reasons != tuple(sorted(set(omission_reasons)))
       or any(reason not in _OMISSION_REASONS for reason in omission_reasons)
@@ -217,6 +251,25 @@ class IssueNegativeRecord:
     fixed_negative_ids = _canonical_string_list(
       fixed_negative_ids_value, f"{context} fixed-negative IDs"
     )
+    known_bib_keys = _canonical_string_list(
+      known_bib_keys_value, f"{context} known bibliography keys"
+    )
+    component_titles = _canonical_string_list(
+      component_titles_value, f"{context} component titles"
+    )
+    component_input_hashes = _canonical_string_list(
+      component_input_hashes_value, f"{context} component input hashes"
+    )
+    if (
+      any(title_value != normalize_title(title_value) for title_value in component_titles)
+      or normalize_title(title) not in component_titles
+    ):
+      raise ValueError(f"{context} component titles are invalid")
+    if (
+      any(_SHA256_RE.fullmatch(value) is None for value in component_input_hashes)
+      or input_hash not in component_input_hashes
+    ):
+      raise ValueError(f"{context} component input hashes are invalid")
     if bool(bibliography_keys) != (OMITTED_BIBLIOGRAPHY in omission_reasons):
       raise ValueError(f"{context} bibliography overlap provenance is invalid")
     if bool(fixed_negative_ids) != (OMITTED_FIXED in omission_reasons):
@@ -236,14 +289,23 @@ class IssueNegativeRecord:
       omission_reasons=omission_reasons,
       bibliography_keys=bibliography_keys,
       fixed_negative_ids=fixed_negative_ids,
+      known_bib_keys=known_bib_keys,
+      component_titles=component_titles,
+      component_input_hashes=component_input_hashes,
     )
 
 
 def _canonical_string_list(value: Any, context: str) -> tuple[str, ...]:
-  if not isinstance(value, list):
+  if (
+    not isinstance(value, list)
+    or any(not isinstance(item, str) for item in value)
+  ):
     raise ValueError(f"{context} must be a list")
-  result = tuple(str(item).strip() for item in value)
-  if any(not item for item in result) or result != tuple(sorted(set(result))):
+  result = tuple(value)
+  if (
+    any(not item or item != item.strip() for item in result)
+    or result != tuple(sorted(set(result)))
+  ):
     raise ValueError(f"{context} must contain unique sorted strings")
   return result
 
@@ -261,6 +323,7 @@ class _Candidate:
   metadata_hash: str
   version: str
   managed_updated: str
+  known_bib_key: str
 
 
 class _UnionFind:
@@ -339,12 +402,16 @@ def sync_issue_negatives(
   ):
     raise ValueError(
       "Configured paper repository does not match GITHUB_REPOSITORY"
-    )
-  github = client or GitHubClient(configured_repository, github_token)
-  works = canonicalize_entries(load_bibliography(config.bibliography_path))
-  positive_aliases, positive_inputs, positive_titles = _bibliography_identity(
-    works
   )
+  github = client or GitHubClient(configured_repository, github_token)
+  bibliography_entries = load_bibliography(config.bibliography_path)
+  works = canonicalize_entries(bibliography_entries)
+  (
+    positive_aliases,
+    positive_inputs,
+    positive_titles,
+    bibliography_entry_keys,
+  ) = _bibliography_identity(works, bibliography_entries)
   fixed_aliases, fixed_inputs, fixed_titles = _fixed_negative_identity(
     Path(config.negative_corpus_path)
   )
@@ -354,6 +421,7 @@ def sync_issue_negatives(
     positive_aliases=positive_aliases,
     positive_inputs=positive_inputs,
     positive_titles=positive_titles,
+    bibliography_entry_keys=bibliography_entry_keys,
     fixed_aliases=fixed_aliases,
     fixed_inputs=fixed_inputs,
     fixed_titles=fixed_titles,
@@ -545,6 +613,19 @@ def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
     raise GitHubError(
       f"Managed negative issue #{number} has no GitHub issue URL"
     )
+  known_bib_key_value = meta.get("known_bib_key")
+  if known_bib_key_value is None:
+    known_bib_key = ""
+  elif (
+    not isinstance(known_bib_key_value, str)
+    or not known_bib_key_value
+    or known_bib_key_value != known_bib_key_value.strip()
+  ):
+    raise GitHubError(
+      f"Managed negative issue #{number} has an invalid known bibliography key"
+    )
+  else:
+    known_bib_key = known_bib_key_value
   return _Candidate(
     number=number,
     node_id=node_id,
@@ -557,6 +638,7 @@ def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
     metadata_hash=metadata_hash,
     version=str(meta.get("version") or ""),
     managed_updated=str(meta.get("updated") or ""),
+    known_bib_key=known_bib_key,
   )
 
 
@@ -566,6 +648,7 @@ def _canonical_records(
   positive_aliases: Mapping[str, set[str]],
   positive_inputs: Mapping[str, set[str]],
   positive_titles: Mapping[str, set[str]],
+  bibliography_entry_keys: set[str],
   fixed_aliases: Mapping[str, set[str]],
   fixed_inputs: Mapping[str, set[str]],
   fixed_titles: Mapping[str, set[str]],
@@ -648,10 +731,17 @@ def _canonical_records(
       for member in members
       if (normalized := normalize_title(member.title))
     }
+    component_input_hashes = {
+      member.input_hash for member in members
+    }
+    known_bib_keys = {
+      member.known_bib_key for member in members if member.known_bib_key
+    }
     bibliography_keys = set().union(
       *(positive_aliases.get(alias, set()) for alias in aliases),
       *(positive_inputs.get(member.input_hash, set()) for member in members),
       *(positive_titles.get(title, set()) for title in member_titles),
+      known_bib_keys & bibliography_entry_keys,
     )
     fixed_negative_ids = set().union(
       *(fixed_aliases.get(alias, set()) for alias in aliases),
@@ -682,6 +772,9 @@ def _canonical_records(
         omission_reasons=omission_reasons,
         bibliography_keys=tuple(sorted(bibliography_keys)),
         fixed_negative_ids=tuple(sorted(fixed_negative_ids)),
+        known_bib_keys=tuple(sorted(known_bib_keys)),
+        component_titles=tuple(sorted(member_titles)),
+        component_input_hashes=tuple(sorted(component_input_hashes)),
       )
     )
   records.sort(key=lambda record: (record.work_id, record.issue_numbers))
@@ -804,14 +897,21 @@ def _candidate_revision_key(
 
 def _bibliography_identity(
   works: Sequence[CanonicalWork],
+  entries: Sequence[BibliographyEntry],
 ) -> tuple[
   dict[str, set[str]],
   dict[str, set[str]],
   dict[str, set[str]],
+  set[str],
 ]:
   aliases: dict[str, set[str]] = {}
   inputs: dict[str, set[str]] = {}
   titles: dict[str, set[str]] = {}
+  entry_keys = {
+    alias
+    for work in works
+    for alias in work.aliases
+  }
   for work in works:
     work_aliases = {
       alias
@@ -830,7 +930,27 @@ def _bibliography_identity(
     ).add(work.citekey)
     if normalized_title := normalize_title(work.title):
       titles.setdefault(normalized_title, set()).add(work.citekey)
-  return aliases, inputs, titles
+  owner_by_key = {
+    alias: work.citekey
+    for work in works
+    for alias in work.aliases
+  }
+  for entry in entries:
+    owner = owner_by_key.get(entry.key, entry.key)
+    if normalized_title := normalize_title(entry.title):
+      titles.setdefault(normalized_title, set()).add(owner)
+    if entry.abstract:
+      inputs.setdefault(
+        embedding_input_hash(entry.title, entry.abstract), set()
+      ).add(owner)
+    title_alias = strict_title_alias(
+      entry.title,
+      str(entry.fields.get("author") or ""),
+      str(entry.fields.get("year") or ""),
+    )
+    if title_alias:
+      aliases.setdefault(title_alias, set()).add(owner)
+  return aliases, inputs, titles, entry_keys
 
 
 def _fixed_negative_identity(

--- a/scripts/paperbot/issue_negatives.py
+++ b/scripts/paperbot/issue_negatives.py
@@ -49,6 +49,27 @@ _ABSTRACT_RE = re.compile(
   re.DOTALL,
 )
 _VERSION_RE = re.compile(r"\d+")
+_ISSUE_URL_NUMBER_RE = re.compile(r"/issues/(\d+)(?:[/?#].*)?$")
+_MANAGED_HASH_FIELDS = frozenset({
+  "title",
+  "abstract",
+  "bibtex",
+  "identifiers",
+  "version",
+  "authors",
+  "venue",
+  "url",
+  "created",
+  "updated",
+  "license",
+})
+_PREPRINT_DOI_PREFIXES = (
+  "10.1101/",
+  "10.21203/rs.",
+  "10.26434/",
+  "10.48550/arxiv.",
+  "10.64898/",
+)
 
 
 @dataclass(frozen=True)
@@ -90,9 +111,18 @@ class IssueNegativeRecord:
   def from_mapping(
     cls, value: Mapping[str, Any], *, context: str = "issue-negative record"
   ) -> IssueNegativeRecord:
-    if value.get("schema_version") != ISSUE_NEGATIVE_SCHEMA:
+    schema_version = value.get("schema_version")
+    if (
+      not isinstance(schema_version, int)
+      or isinstance(schema_version, bool)
+      or schema_version != ISSUE_NEGATIVE_SCHEMA
+    ):
       raise ValueError(f"{context} has an unsupported schema")
-    work_id = normalize_alias(str(value.get("work_id") or ""))
+    raw_work_id = value.get("work_id")
+    work_id_text = (
+      raw_work_id.strip() if isinstance(raw_work_id, str) else ""
+    )
+    work_id = normalize_alias(work_id_text)
     aliases_value = value.get("aliases")
     numbers_value = value.get("issue_numbers")
     urls_value = value.get("issue_urls")
@@ -105,14 +135,24 @@ class IssueNegativeRecord:
     omission_reasons_value = value.get("omission_reasons")
     bibliography_keys_value = value.get("bibliography_keys")
     fixed_negative_ids_value = value.get("fixed_negative_ids")
-    if not work_id or not title or not abstract:
+    if (
+      not work_id
+      or work_id != work_id_text
+      or not title
+      or not abstract
+    ):
       raise ValueError(f"{context} is missing its identity, title, or abstract")
-    if not isinstance(aliases_value, list):
+    if (
+      not isinstance(aliases_value, list)
+      or any(not isinstance(alias, str) for alias in aliases_value)
+    ):
       raise ValueError(f"{context} aliases must be a list")
-    aliases = tuple(normalize_alias(str(alias)) for alias in aliases_value)
+    raw_aliases = tuple(alias.strip() for alias in aliases_value)
+    aliases = tuple(normalize_alias(alias) for alias in raw_aliases)
     if (
       not aliases
       or any(not alias for alias in aliases)
+      or aliases != raw_aliases
       or aliases != tuple(sorted(set(aliases)))
       or work_id not in aliases
     ):
@@ -137,11 +177,21 @@ class IssueNegativeRecord:
       raise ValueError(f"{context} selected issue number is invalid")
     if (
       not isinstance(urls_value, list)
+      or not urls_value
       or any(not isinstance(url, str) or not url.strip() for url in urls_value)
     ):
       raise ValueError(f"{context} issue URLs are invalid")
     issue_urls = tuple(str(url).strip() for url in urls_value)
-    if issue_urls != tuple(sorted(set(issue_urls))):
+    url_numbers = {
+      int(match.group(1))
+      for url in issue_urls
+      if (match := _ISSUE_URL_NUMBER_RE.search(url))
+    }
+    if (
+      issue_urls != tuple(sorted(set(issue_urls)))
+      or len(url_numbers) != len(issue_urls)
+      or url_numbers != set(issue_numbers)
+    ):
       raise ValueError(f"{context} issue URLs are not unique and sorted")
     if _SHA256_RE.fullmatch(metadata_hash) is None:
       raise ValueError(f"{context} metadata hash is invalid")
@@ -260,6 +310,16 @@ def load_issue_negative_snapshot(path: Path | str) -> list[IssueNegativeRecord]:
     raise ValueError("Issue-negative snapshot is not deterministically sorted")
   if len({record.work_id for record in records}) != len(records):
     raise ValueError("Issue-negative snapshot contains duplicate work identities")
+  issue_owners: dict[int, str] = {}
+  for record in records:
+    for issue_number in record.issue_numbers:
+      previous = issue_owners.get(issue_number)
+      if previous is not None:
+        raise ValueError(
+          f"GitHub issue #{issue_number} appears in issue-negative works "
+          f"{previous} and {record.work_id}"
+        )
+      issue_owners[issue_number] = record.work_id
   return records
 
 
@@ -282,8 +342,10 @@ def sync_issue_negatives(
     )
   github = client or GitHubClient(configured_repository, github_token)
   works = canonicalize_entries(load_bibliography(config.bibliography_path))
-  positive_aliases, positive_inputs = _bibliography_identity(works)
-  fixed_aliases, fixed_inputs = _fixed_negative_identity(
+  positive_aliases, positive_inputs, positive_titles = _bibliography_identity(
+    works
+  )
+  fixed_aliases, fixed_inputs, fixed_titles = _fixed_negative_identity(
     Path(config.negative_corpus_path)
   )
   raw_candidates = _eligible_candidates(github)
@@ -291,8 +353,10 @@ def sync_issue_negatives(
     raw_candidates,
     positive_aliases=positive_aliases,
     positive_inputs=positive_inputs,
+    positive_titles=positive_titles,
     fixed_aliases=fixed_aliases,
     fixed_inputs=fixed_inputs,
+    fixed_titles=fixed_titles,
   )
   output_path = Path(config.artifact_dir) / ISSUE_NEGATIVE_CORPUS
   _write_snapshot(output_path, records)
@@ -363,9 +427,14 @@ def _eligible_candidates(client: GitHubClient) -> list[_Candidate]:
 
 
 def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
-  number = int(raw.get("number") or 0)
-  if number <= 0:
+  raw_number = raw.get("number")
+  if (
+    not isinstance(raw_number, int)
+    or isinstance(raw_number, bool)
+    or raw_number <= 0
+  ):
     raise GitHubError("Managed negative issue is missing its issue number")
+  number = raw_number
   node_id = str(raw.get("node_id") or "").strip()
   if not node_id:
     raise GitHubError(
@@ -416,6 +485,13 @@ def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
     raise GitHubError(
       f"Managed negative issue #{number} has no field hashes"
     )
+  if set(field_hashes) != _MANAGED_HASH_FIELDS or any(
+    not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None
+    for value in field_hashes.values()
+  ):
+    raise GitHubError(
+      f"Managed negative issue #{number} has incomplete or invalid field hashes"
+    )
   for field, value in (("title", title), ("abstract", abstract)):
     expected = str(field_hashes.get(field) or "")
     actual = hashlib.sha256(value.encode("utf-8")).hexdigest()
@@ -436,6 +512,15 @@ def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
     raise GitHubError(
       f"Managed negative issue #{number} identifiers do not match their hash"
     )
+  for field in ("version", "updated"):
+    value = str(meta.get(field) or "")
+    expected = str(field_hashes.get(field) or "")
+    actual = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if expected != actual:
+      raise GitHubError(
+        f"Managed negative issue #{number} {field} does not match its "
+        "paperbot hash"
+      )
   aliases = tuple(normalize_alias(str(alias)) for alias in aliases_value)
   raw_work_id = str(meta.get("work_id") or "")
   work_id = normalize_alias(raw_work_id)
@@ -480,13 +565,15 @@ def _canonical_records(
   *,
   positive_aliases: Mapping[str, set[str]],
   positive_inputs: Mapping[str, set[str]],
+  positive_titles: Mapping[str, set[str]],
   fixed_aliases: Mapping[str, set[str]],
   fixed_inputs: Mapping[str, set[str]],
+  fixed_titles: Mapping[str, set[str]],
 ) -> list[IssueNegativeRecord]:
   groups = _UnionFind(len(candidates))
   alias_owner: dict[str, int] = {}
   title_aliases: dict[str, list[int]] = {}
-  input_owner: dict[str, int] = {}
+  input_indexes: dict[str, list[int]] = {}
   for index, candidate in enumerate(candidates):
     for alias in candidate.aliases:
       if alias.startswith("title:"):
@@ -497,11 +584,30 @@ def _canonical_records(
         alias_owner[alias] = index
       else:
         groups.union(index, previous)
-    previous_input = input_owner.get(candidate.input_hash)
-    if previous_input is None:
-      input_owner[candidate.input_hash] = index
-    else:
-      groups.union(index, previous_input)
+    input_indexes.setdefault(candidate.input_hash, []).append(index)
+
+  # Exact duplicate model inputs normally identify duplicate paper threads.
+  # Refuse to use that shortcut if the threads also carry contradictory
+  # same-stage identifiers: identical publisher text is not proof that two
+  # separately identified journal articles are one work.
+  for input_hash, indexes in sorted(input_indexes.items()):
+    roots = sorted({groups.find(index) for index in indexes})
+    if len(roots) < 2:
+      continue
+    components = _candidate_components(candidates, groups, roots)
+    if _identity_components_conflict(tuple(components.values())):
+      numbers = sorted(
+        candidate.number
+        for members in components.values()
+        for candidate in members
+      )
+      raise GitHubError(
+        f"Exact SPECTER2 input {input_hash} ambiguously matches managed "
+        f"negative issues {', '.join(f'#{number}' for number in numbers)}"
+      )
+    first, *rest = roots
+    for root in rest:
+      groups.union(first, root)
 
   # The strict title/first-author/year fallback can join a preprint to its
   # publication, but it must not silently collapse distinct strong identities.
@@ -509,15 +615,8 @@ def _canonical_records(
     roots = sorted({groups.find(index) for index in indexes})
     if len(roots) < 2:
       continue
-    components = {
-      root: [
-        candidate
-        for index, candidate in enumerate(candidates)
-        if groups.find(index) == root
-      ]
-      for root in roots
-    }
-    if _title_components_conflict(tuple(components.values())):
+    components = _candidate_components(candidates, groups, roots)
+    if _identity_components_conflict(tuple(components.values())):
       numbers = sorted(
         candidate.number
         for members in components.values()
@@ -544,13 +643,20 @@ def _canonical_records(
     issue_urls = tuple(
       sorted({member.url for member in members if member.url})
     )
+    member_titles = {
+      normalized
+      for member in members
+      if (normalized := normalize_title(member.title))
+    }
     bibliography_keys = set().union(
       *(positive_aliases.get(alias, set()) for alias in aliases),
-      positive_inputs.get(representative.input_hash, set()),
+      *(positive_inputs.get(member.input_hash, set()) for member in members),
+      *(positive_titles.get(title, set()) for title in member_titles),
     )
     fixed_negative_ids = set().union(
       *(fixed_aliases.get(alias, set()) for alias in aliases),
-      fixed_inputs.get(representative.input_hash, set()),
+      *(fixed_inputs.get(member.input_hash, set()) for member in members),
+      *(fixed_titles.get(title, set()) for title in member_titles),
     )
     omission_reasons = tuple(
       reason
@@ -586,14 +692,32 @@ def _canonical_records(
   return records
 
 
-def _title_components_conflict(
+def _candidate_components(
+  candidates: Sequence[_Candidate],
+  groups: _UnionFind,
+  roots: Sequence[int],
+) -> dict[int, list[_Candidate]]:
+  wanted = set(roots)
+  components = {root: [] for root in roots}
+  for index, candidate in enumerate(candidates):
+    root = groups.find(index)
+    if root in wanted:
+      components[root].append(candidate)
+  return components
+
+
+def _identity_components_conflict(
   components: Sequence[Sequence[_Candidate]],
 ) -> bool:
-  """Reject title-only merges carrying contradictory same-stage identifiers."""
+  """Reject fallback merges carrying contradictory same-stage identifiers."""
 
   identities = [_component_strong_identities(component) for component in components]
   for kind in ("pmid", "arxiv"):
-    nonempty = [identity[kind] for identity in identities if identity[kind]]
+    nonempty = [
+      identity[kind]
+      for identity in identities
+      if isinstance(identity[kind], set) and identity[kind]
+    ]
     if len(nonempty) > 1 and not set.intersection(*nonempty):
       return True
   preprint_dois = [
@@ -604,25 +728,45 @@ def _title_components_conflict(
   publication_dois = [
     identity["publication_doi"]
     for identity in identities
-    if identity["publication_doi"]
+    if isinstance(identity["publication_doi"], set)
+    and identity["publication_doi"]
   ]
-  return (
+  if (
     len(preprint_dois) > 1
     and not set.intersection(*preprint_dois)
   ) or (
     len(publication_dois) > 1
     and not set.intersection(*publication_dois)
+  ):
+    return True
+  source_kinds = set().union(
+    *(
+      set(identity["source_ids"])
+      for identity in identities
+      if isinstance(identity["source_ids"], Mapping)
+    )
   )
+  for kind in source_kinds:
+    nonempty = [
+      identity["source_ids"][kind]
+      for identity in identities
+      if isinstance(identity["source_ids"], Mapping)
+      and identity["source_ids"].get(kind)
+    ]
+    if len(nonempty) > 1 and not set.intersection(*nonempty):
+      return True
+  return False
 
 
 def _component_strong_identities(
   candidates: Sequence[_Candidate],
-) -> dict[str, set[str]]:
+) -> dict[str, set[str] | dict[str, set[str]]]:
   result = {
     "pmid": set(),
     "arxiv": set(),
     "preprint_doi": set(),
     "publication_doi": set(),
+    "source_ids": {},
   }
   for candidate in candidates:
     for alias in candidate.aliases:
@@ -634,33 +778,40 @@ def _component_strong_identities(
           "preprint_doi" if _is_preprint_doi(value) else "publication_doi"
         )
         result[destination].add(value)
+      elif kind and kind != "title" and value:
+        source_ids = result["source_ids"]
+        assert isinstance(source_ids, dict)
+        source_ids.setdefault(kind, set()).add(value)
   return result
 
 
 def _is_preprint_doi(doi: str) -> bool:
-  return doi.startswith(
-    ("10.1101/", "10.64898/", "10.26434/", "10.48550/arxiv.")
-  )
+  return doi.startswith(_PREPRINT_DOI_PREFIXES)
 
 
 def _candidate_revision_key(
   candidate: _Candidate,
-) -> tuple[str, int, str, int]:
+) -> tuple[str, int, int, str]:
   version_match = _VERSION_RE.search(candidate.version)
   version = int(version_match.group(0)) if version_match else 0
   return (
     candidate.managed_updated,
     version,
+    candidate.number,
     candidate.metadata_hash,
-    -candidate.number,
   )
 
 
 def _bibliography_identity(
   works: Sequence[CanonicalWork],
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+) -> tuple[
+  dict[str, set[str]],
+  dict[str, set[str]],
+  dict[str, set[str]],
+]:
   aliases: dict[str, set[str]] = {}
   inputs: dict[str, set[str]] = {}
+  titles: dict[str, set[str]] = {}
   for work in works:
     work_aliases = {
       alias
@@ -677,22 +828,34 @@ def _bibliography_identity(
     inputs.setdefault(
       embedding_input_hash(work.title, work.abstract), set()
     ).add(work.citekey)
-  return aliases, inputs
+    if normalized_title := normalize_title(work.title):
+      titles.setdefault(normalized_title, set()).add(work.citekey)
+  return aliases, inputs, titles
 
 
 def _fixed_negative_identity(
   path: Path,
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+) -> tuple[
+  dict[str, set[str]],
+  dict[str, set[str]],
+  dict[str, set[str]],
+]:
   aliases: dict[str, set[str]] = {}
   inputs: dict[str, set[str]] = {}
+  titles: dict[str, set[str]] = {}
   if not path.exists():
-    return aliases, inputs
+    return aliases, inputs, titles
   for line_number, line in enumerate(
     path.read_text(encoding="utf-8").splitlines(), 1
   ):
     if not line.strip():
       continue
-    payload = json.loads(line)
+    try:
+      payload = json.loads(line)
+    except json.JSONDecodeError as error:
+      raise ValueError(
+        f"Invalid fixed-negative JSON at {path.name}:{line_number}"
+      ) from error
     if not isinstance(payload, Mapping):
       raise ValueError(
         f"Expected an object at {path.name}:{line_number}"
@@ -704,6 +867,11 @@ def _fixed_negative_identity(
       raise ValueError(
         f"Fixed negative at {path.name}:{line_number} has no work identity"
       )
+    aliases_value = payload.get("aliases") or []
+    if not isinstance(aliases_value, list):
+      raise ValueError(
+        f"Fixed negative aliases at {path.name}:{line_number} must be a list"
+      )
     row_aliases: set[str] = set()
     for value in (
       payload.get("work_id"),
@@ -711,12 +879,14 @@ def _fixed_negative_identity(
       f"pmid:{payload.get('pmid')}" if payload.get("pmid") else "",
       f"doi:{payload.get('doi')}" if payload.get("doi") else "",
       f"arxiv:{payload.get('arxiv_id')}" if payload.get("arxiv_id") else "",
-      *(payload.get("aliases") or []),
+      *aliases_value,
     ):
       if alias := normalize_alias(str(value or "")):
         row_aliases.add(alias)
     title = str(payload.get("title") or "").strip()
     abstract = str(payload.get("abstract") or "").strip()
+    if normalized_title := normalize_title(title):
+      titles.setdefault(normalized_title, set()).add(fixed_id)
     if title and abstract:
       inputs.setdefault(embedding_input_hash(title, abstract), set()).add(
         fixed_id
@@ -734,7 +904,7 @@ def _fixed_negative_identity(
       row_aliases.add(title_alias)
     for alias in row_aliases:
       aliases.setdefault(alias, set()).add(fixed_id)
-  return aliases, inputs
+  return aliases, inputs, titles
 
 
 def strict_title_alias(title: str, authors: str, year: str) -> str:

--- a/scripts/paperbot/issue_negatives.py
+++ b/scripts/paperbot/issue_negatives.py
@@ -1,0 +1,797 @@
+"""Deterministic human-feedback negatives collected from managed GitHub issues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, Iterable, Mapping, Sequence
+
+from .bibliography import (
+  CanonicalWork,
+  canonicalize_entries,
+  embedding_input_hash,
+  load_bibliography,
+)
+from .github import (
+  GITHUB_ACTIONS_BOT_LOGIN,
+  MANAGED_BLOCK_BEGIN,
+  MANAGED_BLOCK_END,
+  META_PREFIX,
+  GitHubClient,
+  GitHubError,
+  normalize_alias,
+  parse_managed_meta,
+)
+from .records import first_author_key, normalize_title
+
+
+ISSUE_NEGATIVE_SCHEMA = 1
+ISSUE_NEGATIVE_CORPUS = "issue_negatives.jsonl"
+ISSUE_NEGATIVE_MATRIX = "issue_negative_embeddings.npy"
+ISSUE_NEGATIVE_MANIFEST = "issue_negative_manifest.jsonl"
+OMITTED_BIBLIOGRAPHY = "bibliography_overlap"
+OMITTED_FIXED = "fixed_negative_overlap"
+_OMISSION_REASONS = {OMITTED_BIBLIOGRAPHY, OMITTED_FIXED}
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_MANAGED_BLOCK_RE = re.compile(
+  re.escape(MANAGED_BLOCK_BEGIN)
+  + r"(.*?)"
+  + re.escape(MANAGED_BLOCK_END),
+  re.DOTALL,
+)
+_ABSTRACT_RE = re.compile(
+  r"(?:^|\n)## Abstract\s*\n\s*(.*?)\s*\n## BibTeX(?:\n|$)",
+  re.DOTALL,
+)
+_VERSION_RE = re.compile(r"\d+")
+
+
+@dataclass(frozen=True)
+class IssueNegativeRecord:
+  schema_version: int
+  work_id: str
+  aliases: tuple[str, ...]
+  issue_numbers: tuple[int, ...]
+  issue_urls: tuple[str, ...]
+  selected_issue_number: int
+  title: str
+  abstract: str
+  input_hash: str
+  metadata_hash: str
+  active: bool
+  omission_reasons: tuple[str, ...] = ()
+  bibliography_keys: tuple[str, ...] = ()
+  fixed_negative_ids: tuple[str, ...] = ()
+
+  def to_dict(self) -> dict[str, Any]:
+    return {
+      "schema_version": self.schema_version,
+      "work_id": self.work_id,
+      "aliases": list(self.aliases),
+      "issue_numbers": list(self.issue_numbers),
+      "issue_urls": list(self.issue_urls),
+      "selected_issue_number": self.selected_issue_number,
+      "title": self.title,
+      "abstract": self.abstract,
+      "input_hash": self.input_hash,
+      "metadata_hash": self.metadata_hash,
+      "active": self.active,
+      "omission_reasons": list(self.omission_reasons),
+      "bibliography_keys": list(self.bibliography_keys),
+      "fixed_negative_ids": list(self.fixed_negative_ids),
+    }
+
+  @classmethod
+  def from_mapping(
+    cls, value: Mapping[str, Any], *, context: str = "issue-negative record"
+  ) -> IssueNegativeRecord:
+    if value.get("schema_version") != ISSUE_NEGATIVE_SCHEMA:
+      raise ValueError(f"{context} has an unsupported schema")
+    work_id = normalize_alias(str(value.get("work_id") or ""))
+    aliases_value = value.get("aliases")
+    numbers_value = value.get("issue_numbers")
+    urls_value = value.get("issue_urls")
+    title = str(value.get("title") or "").strip()
+    abstract = str(value.get("abstract") or "").strip()
+    input_hash = str(value.get("input_hash") or "").strip().casefold()
+    metadata_hash = str(value.get("metadata_hash") or "").strip().casefold()
+    selected_issue_number = value.get("selected_issue_number")
+    active = value.get("active")
+    omission_reasons_value = value.get("omission_reasons")
+    bibliography_keys_value = value.get("bibliography_keys")
+    fixed_negative_ids_value = value.get("fixed_negative_ids")
+    if not work_id or not title or not abstract:
+      raise ValueError(f"{context} is missing its identity, title, or abstract")
+    if not isinstance(aliases_value, list):
+      raise ValueError(f"{context} aliases must be a list")
+    aliases = tuple(normalize_alias(str(alias)) for alias in aliases_value)
+    if (
+      not aliases
+      or any(not alias for alias in aliases)
+      or aliases != tuple(sorted(set(aliases)))
+      or work_id not in aliases
+    ):
+      raise ValueError(f"{context} aliases are invalid or noncanonical")
+    if (
+      not isinstance(numbers_value, list)
+      or not numbers_value
+      or any(
+        not isinstance(number, int) or isinstance(number, bool) or number <= 0
+        for number in numbers_value
+      )
+    ):
+      raise ValueError(f"{context} issue numbers are invalid")
+    issue_numbers = tuple(numbers_value)
+    if issue_numbers != tuple(sorted(set(issue_numbers))):
+      raise ValueError(f"{context} issue numbers are not unique and sorted")
+    if (
+      not isinstance(selected_issue_number, int)
+      or isinstance(selected_issue_number, bool)
+      or selected_issue_number not in issue_numbers
+    ):
+      raise ValueError(f"{context} selected issue number is invalid")
+    if (
+      not isinstance(urls_value, list)
+      or any(not isinstance(url, str) or not url.strip() for url in urls_value)
+    ):
+      raise ValueError(f"{context} issue URLs are invalid")
+    issue_urls = tuple(str(url).strip() for url in urls_value)
+    if issue_urls != tuple(sorted(set(issue_urls))):
+      raise ValueError(f"{context} issue URLs are not unique and sorted")
+    if _SHA256_RE.fullmatch(metadata_hash) is None:
+      raise ValueError(f"{context} metadata hash is invalid")
+    if (
+      _SHA256_RE.fullmatch(input_hash) is None
+      or input_hash != embedding_input_hash(title, abstract)
+    ):
+      raise ValueError(f"{context} SPECTER2 input hash is invalid")
+    if active is not True and active is not False:
+      raise ValueError(f"{context} active flag is invalid")
+    if not isinstance(omission_reasons_value, list):
+      raise ValueError(f"{context} omission reasons must be a list")
+    omission_reasons = tuple(str(reason) for reason in omission_reasons_value)
+    if (
+      omission_reasons != tuple(sorted(set(omission_reasons)))
+      or any(reason not in _OMISSION_REASONS for reason in omission_reasons)
+      or active == bool(omission_reasons)
+    ):
+      raise ValueError(f"{context} has invalid omission reasons")
+    bibliography_keys = _canonical_string_list(
+      bibliography_keys_value, f"{context} bibliography keys"
+    )
+    fixed_negative_ids = _canonical_string_list(
+      fixed_negative_ids_value, f"{context} fixed-negative IDs"
+    )
+    if bool(bibliography_keys) != (OMITTED_BIBLIOGRAPHY in omission_reasons):
+      raise ValueError(f"{context} bibliography overlap provenance is invalid")
+    if bool(fixed_negative_ids) != (OMITTED_FIXED in omission_reasons):
+      raise ValueError(f"{context} fixed-negative overlap provenance is invalid")
+    return cls(
+      schema_version=ISSUE_NEGATIVE_SCHEMA,
+      work_id=work_id,
+      aliases=aliases,
+      issue_numbers=issue_numbers,
+      issue_urls=issue_urls,
+      selected_issue_number=selected_issue_number,
+      title=title,
+      abstract=abstract,
+      input_hash=input_hash,
+      metadata_hash=metadata_hash,
+      active=bool(active),
+      omission_reasons=omission_reasons,
+      bibliography_keys=bibliography_keys,
+      fixed_negative_ids=fixed_negative_ids,
+    )
+
+
+def _canonical_string_list(value: Any, context: str) -> tuple[str, ...]:
+  if not isinstance(value, list):
+    raise ValueError(f"{context} must be a list")
+  result = tuple(str(item).strip() for item in value)
+  if any(not item for item in result) or result != tuple(sorted(set(result))):
+    raise ValueError(f"{context} must contain unique sorted strings")
+  return result
+
+
+@dataclass(frozen=True)
+class _Candidate:
+  number: int
+  node_id: str
+  url: str
+  work_id: str
+  aliases: tuple[str, ...]
+  title: str
+  abstract: str
+  input_hash: str
+  metadata_hash: str
+  version: str
+  managed_updated: str
+
+
+class _UnionFind:
+  def __init__(self, size: int) -> None:
+    self.parents = list(range(size))
+
+  def find(self, index: int) -> int:
+    while self.parents[index] != index:
+      self.parents[index] = self.parents[self.parents[index]]
+      index = self.parents[index]
+    return index
+
+  def union(self, left: int, right: int) -> None:
+    left_root = self.find(left)
+    right_root = self.find(right)
+    if left_root != right_root:
+      self.parents[max(left_root, right_root)] = min(left_root, right_root)
+
+
+def load_issue_negative_snapshot(path: Path | str) -> list[IssueNegativeRecord]:
+  snapshot_path = Path(path)
+  if not snapshot_path.exists():
+    return []
+  records: list[IssueNegativeRecord] = []
+  for line_number, line in enumerate(
+    snapshot_path.read_text(encoding="utf-8").splitlines(), 1
+  ):
+    if not line.strip():
+      continue
+    try:
+      payload = json.loads(line)
+    except json.JSONDecodeError as error:
+      raise ValueError(
+        f"Invalid issue-negative JSON at {snapshot_path}:{line_number}"
+      ) from error
+    if not isinstance(payload, Mapping):
+      raise ValueError(
+        f"Expected an object at {snapshot_path}:{line_number}"
+      )
+    records.append(
+      IssueNegativeRecord.from_mapping(
+        payload, context=f"{snapshot_path.name}:{line_number}"
+      )
+    )
+  ordering = [(record.work_id, record.issue_numbers) for record in records]
+  if ordering != sorted(ordering):
+    raise ValueError("Issue-negative snapshot is not deterministically sorted")
+  if len({record.work_id for record in records}) != len(records):
+    raise ValueError("Issue-negative snapshot contains duplicate work identities")
+  return records
+
+
+def sync_issue_negatives(
+  config: Any,
+  *,
+  github_token: str = "",
+  client: GitHubClient | None = None,
+) -> dict[str, Any]:
+  """Snapshot current closed ``negative`` issues for the next model fit."""
+
+  configured_repository = str(config.repository)
+  workflow_repository = os.getenv("GITHUB_REPOSITORY", "").strip()
+  if (
+    workflow_repository
+    and workflow_repository.casefold() != configured_repository.casefold()
+  ):
+    raise ValueError(
+      "Configured paper repository does not match GITHUB_REPOSITORY"
+    )
+  github = client or GitHubClient(configured_repository, github_token)
+  works = canonicalize_entries(load_bibliography(config.bibliography_path))
+  positive_aliases, positive_inputs = _bibliography_identity(works)
+  fixed_aliases, fixed_inputs = _fixed_negative_identity(
+    Path(config.negative_corpus_path)
+  )
+  raw_candidates = _eligible_candidates(github)
+  records = _canonical_records(
+    raw_candidates,
+    positive_aliases=positive_aliases,
+    positive_inputs=positive_inputs,
+    fixed_aliases=fixed_aliases,
+    fixed_inputs=fixed_inputs,
+  )
+  output_path = Path(config.artifact_dir) / ISSUE_NEGATIVE_CORPUS
+  _write_snapshot(output_path, records)
+  omissions: dict[str, int] = {}
+  for record in records:
+    for reason in record.omission_reasons:
+      omissions[reason] = omissions.get(reason, 0) + 1
+  return {
+    "ok": True,
+    "path": str(output_path),
+    "eligible_issue_count": len(raw_candidates),
+    "canonical_work_count": len(records),
+    "active_count": sum(record.active for record in records),
+    "duplicate_issue_count": len(raw_candidates) - len(records),
+    "omission_counts": dict(sorted(omissions.items())),
+  }
+
+
+def _eligible_candidates(client: GitHubClient) -> list[_Candidate]:
+  seen: dict[int, _Candidate] = {}
+  seen_nodes: dict[str, _Candidate] = {}
+  # Do not use a server-side label filter: selection must remain correct if the
+  # repository spells the label with different capitalization.
+  for raw in client.list_issues(label=None):
+    if "pull_request" in raw:
+      continue
+    if str(raw.get("state") or "").casefold() != "closed":
+      continue
+    labels = {
+      str(label.get("name", "") if isinstance(label, Mapping) else label).casefold()
+      for label in (raw.get("labels") or [])
+    }
+    if "negative" not in labels:
+      continue
+    author = raw.get("user")
+    login = str(
+      author.get("login", "") if isinstance(author, Mapping) else ""
+    ).casefold()
+    if login != GITHUB_ACTIONS_BOT_LOGIN.casefold():
+      continue
+    # A closed negative produced by another workflow is outside paperbot's
+    # corpus. Conversely, anything carrying the paper label or a paperbot
+    # marker is clearly intended managed data and must validate fail-closed.
+    body = str(raw.get("body") or "")
+    if (
+      "paper" not in labels
+      and MANAGED_BLOCK_BEGIN not in body
+      and MANAGED_BLOCK_END not in body
+      and META_PREFIX not in body
+    ):
+      continue
+    candidate = _candidate_from_issue(raw)
+    previous = seen.get(candidate.number)
+    if previous is not None and previous != candidate:
+      raise GitHubError(
+        f"GitHub issue #{candidate.number} appeared more than once with "
+        "different managed content"
+      )
+    previous_node = seen_nodes.get(candidate.node_id)
+    if previous_node is not None and previous_node != candidate:
+      raise GitHubError(
+        f"GitHub issue node {candidate.node_id!r} appeared with conflicting "
+        f"issue numbers #{previous_node.number} and #{candidate.number}"
+      )
+    seen[candidate.number] = candidate
+    seen_nodes[candidate.node_id] = candidate
+  return sorted(seen.values(), key=lambda candidate: candidate.number)
+
+
+def _candidate_from_issue(raw: Mapping[str, Any]) -> _Candidate:
+  number = int(raw.get("number") or 0)
+  if number <= 0:
+    raise GitHubError("Managed negative issue is missing its issue number")
+  node_id = str(raw.get("node_id") or "").strip()
+  if not node_id:
+    raise GitHubError(
+      f"Managed negative issue #{number} is missing its immutable node ID"
+    )
+  body = str(raw.get("body") or "")
+  block_matches = list(_MANAGED_BLOCK_RE.finditer(body))
+  if (
+    len(block_matches) != 1
+    or body.count(MANAGED_BLOCK_BEGIN) != 1
+    or body.count(MANAGED_BLOCK_END) != 1
+  ):
+    raise GitHubError(
+      f"Managed negative issue #{number} must contain exactly one complete "
+      "paperbot block"
+    )
+  block_match = block_matches[0]
+  block = block_match.group(1)
+  managed_body = block_match.group(0)
+  if body.count(META_PREFIX) != 1 or managed_body.count(META_PREFIX) != 1:
+    raise GitHubError(
+      f"Managed negative issue #{number} must contain exactly one metadata marker"
+    )
+  meta = parse_managed_meta(managed_body)
+  if meta is None:
+    raise GitHubError(
+      f"Managed negative issue #{number} is missing paperbot metadata"
+    )
+  abstract_match = _ABSTRACT_RE.search(block)
+  if (
+    len(re.findall(r"(?m)^## Abstract\s*$", block)) != 1
+    or len(re.findall(r"(?m)^## BibTeX\s*$", block)) != 1
+  ):
+    raise GitHubError(
+      f"Managed negative issue #{number} must contain exactly one abstract "
+      "and BibTeX section"
+    )
+  title = str(raw.get("title") or "").strip()
+  abstract = (
+    abstract_match.group(1).strip() if abstract_match is not None else ""
+  )
+  if not title or not abstract:
+    raise GitHubError(
+      f"Managed negative issue #{number} has no complete title and abstract"
+    )
+  field_hashes = meta.get("field_hashes")
+  if not isinstance(field_hashes, Mapping):
+    raise GitHubError(
+      f"Managed negative issue #{number} has no field hashes"
+    )
+  for field, value in (("title", title), ("abstract", abstract)):
+    expected = str(field_hashes.get(field) or "")
+    actual = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    if expected != actual:
+      raise GitHubError(
+        f"Managed negative issue #{number} {field} does not match its "
+        "paperbot hash"
+      )
+  aliases_value = meta.get("aliases")
+  if not isinstance(aliases_value, list):
+    raise GitHubError(
+      f"Managed negative issue #{number} has invalid aliases"
+    )
+  expected_identifiers = hashlib.sha256(
+    json.dumps(aliases_value, separators=(",", ":")).encode("utf-8")
+  ).hexdigest()
+  if str(field_hashes.get("identifiers") or "") != expected_identifiers:
+    raise GitHubError(
+      f"Managed negative issue #{number} identifiers do not match their hash"
+    )
+  aliases = tuple(normalize_alias(str(alias)) for alias in aliases_value)
+  raw_work_id = str(meta.get("work_id") or "")
+  work_id = normalize_alias(raw_work_id)
+  if (
+    not work_id
+    or work_id != raw_work_id
+    or any(not alias for alias in aliases)
+    or list(aliases) != aliases_value
+    or aliases != tuple(sorted(set(aliases)))
+    or work_id not in aliases
+  ):
+    raise GitHubError(
+      f"Managed negative issue #{number} has noncanonical identity metadata"
+    )
+  metadata_hash = str(meta.get("metadata_hash") or "").strip().casefold()
+  if _SHA256_RE.fullmatch(metadata_hash) is None:
+    raise GitHubError(
+      f"Managed negative issue #{number} has an invalid metadata hash"
+    )
+  url = str(raw.get("html_url") or "").strip()
+  if not url:
+    raise GitHubError(
+      f"Managed negative issue #{number} has no GitHub issue URL"
+    )
+  return _Candidate(
+    number=number,
+    node_id=node_id,
+    url=url,
+    work_id=work_id,
+    aliases=aliases,
+    title=title,
+    abstract=abstract,
+    input_hash=embedding_input_hash(title, abstract),
+    metadata_hash=metadata_hash,
+    version=str(meta.get("version") or ""),
+    managed_updated=str(meta.get("updated") or ""),
+  )
+
+
+def _canonical_records(
+  candidates: Sequence[_Candidate],
+  *,
+  positive_aliases: Mapping[str, set[str]],
+  positive_inputs: Mapping[str, set[str]],
+  fixed_aliases: Mapping[str, set[str]],
+  fixed_inputs: Mapping[str, set[str]],
+) -> list[IssueNegativeRecord]:
+  groups = _UnionFind(len(candidates))
+  alias_owner: dict[str, int] = {}
+  title_aliases: dict[str, list[int]] = {}
+  input_owner: dict[str, int] = {}
+  for index, candidate in enumerate(candidates):
+    for alias in candidate.aliases:
+      if alias.startswith("title:"):
+        title_aliases.setdefault(alias, []).append(index)
+        continue
+      previous = alias_owner.get(alias)
+      if previous is None:
+        alias_owner[alias] = index
+      else:
+        groups.union(index, previous)
+    previous_input = input_owner.get(candidate.input_hash)
+    if previous_input is None:
+      input_owner[candidate.input_hash] = index
+    else:
+      groups.union(index, previous_input)
+
+  # The strict title/first-author/year fallback can join a preprint to its
+  # publication, but it must not silently collapse distinct strong identities.
+  for title_alias, indexes in sorted(title_aliases.items()):
+    roots = sorted({groups.find(index) for index in indexes})
+    if len(roots) < 2:
+      continue
+    components = {
+      root: [
+        candidate
+        for index, candidate in enumerate(candidates)
+        if groups.find(index) == root
+      ]
+      for root in roots
+    }
+    if _title_components_conflict(tuple(components.values())):
+      numbers = sorted(
+        candidate.number
+        for members in components.values()
+        for candidate in members
+      )
+      raise GitHubError(
+        f"Strict title identity {title_alias} ambiguously matches managed "
+        f"negative issues {', '.join(f'#{number}' for number in numbers)}"
+      )
+    first, *rest = roots
+    for root in rest:
+      groups.union(first, root)
+  components: dict[int, list[_Candidate]] = {}
+  for index, candidate in enumerate(candidates):
+    components.setdefault(groups.find(index), []).append(candidate)
+
+  records: list[IssueNegativeRecord] = []
+  for members in components.values():
+    representative = max(members, key=_candidate_revision_key)
+    aliases = tuple(
+      sorted({alias for member in members for alias in member.aliases})
+    )
+    issue_numbers = tuple(sorted(member.number for member in members))
+    issue_urls = tuple(
+      sorted({member.url for member in members if member.url})
+    )
+    bibliography_keys = set().union(
+      *(positive_aliases.get(alias, set()) for alias in aliases),
+      positive_inputs.get(representative.input_hash, set()),
+    )
+    fixed_negative_ids = set().union(
+      *(fixed_aliases.get(alias, set()) for alias in aliases),
+      fixed_inputs.get(representative.input_hash, set()),
+    )
+    omission_reasons = tuple(
+      reason
+      for reason, applies in (
+        (OMITTED_BIBLIOGRAPHY, bool(bibliography_keys)),
+        (OMITTED_FIXED, bool(fixed_negative_ids)),
+      )
+      if applies
+    )
+    records.append(
+      IssueNegativeRecord(
+        schema_version=ISSUE_NEGATIVE_SCHEMA,
+        work_id=representative.work_id,
+        aliases=aliases,
+        issue_numbers=issue_numbers,
+        issue_urls=issue_urls,
+        selected_issue_number=representative.number,
+        title=representative.title,
+        abstract=representative.abstract,
+        input_hash=representative.input_hash,
+        metadata_hash=representative.metadata_hash,
+        active=not omission_reasons,
+        omission_reasons=omission_reasons,
+        bibliography_keys=tuple(sorted(bibliography_keys)),
+        fixed_negative_ids=tuple(sorted(fixed_negative_ids)),
+      )
+    )
+  records.sort(key=lambda record: (record.work_id, record.issue_numbers))
+  if len({record.work_id for record in records}) != len(records):
+    raise GitHubError(
+      "Issue-negative canonicalization produced duplicate work identities"
+    )
+  return records
+
+
+def _title_components_conflict(
+  components: Sequence[Sequence[_Candidate]],
+) -> bool:
+  """Reject title-only merges carrying contradictory same-stage identifiers."""
+
+  identities = [_component_strong_identities(component) for component in components]
+  for kind in ("pmid", "arxiv"):
+    nonempty = [identity[kind] for identity in identities if identity[kind]]
+    if len(nonempty) > 1 and not set.intersection(*nonempty):
+      return True
+  preprint_dois = [
+    identity["preprint_doi"]
+    for identity in identities
+    if identity["preprint_doi"]
+  ]
+  publication_dois = [
+    identity["publication_doi"]
+    for identity in identities
+    if identity["publication_doi"]
+  ]
+  return (
+    len(preprint_dois) > 1
+    and not set.intersection(*preprint_dois)
+  ) or (
+    len(publication_dois) > 1
+    and not set.intersection(*publication_dois)
+  )
+
+
+def _component_strong_identities(
+  candidates: Sequence[_Candidate],
+) -> dict[str, set[str]]:
+  result = {
+    "pmid": set(),
+    "arxiv": set(),
+    "preprint_doi": set(),
+    "publication_doi": set(),
+  }
+  for candidate in candidates:
+    for alias in candidate.aliases:
+      kind, _, value = alias.partition(":")
+      if kind in {"pmid", "arxiv"}:
+        result[kind].add(value)
+      elif kind == "doi":
+        destination = (
+          "preprint_doi" if _is_preprint_doi(value) else "publication_doi"
+        )
+        result[destination].add(value)
+  return result
+
+
+def _is_preprint_doi(doi: str) -> bool:
+  return doi.startswith(
+    ("10.1101/", "10.64898/", "10.26434/", "10.48550/arxiv.")
+  )
+
+
+def _candidate_revision_key(
+  candidate: _Candidate,
+) -> tuple[str, int, str, int]:
+  version_match = _VERSION_RE.search(candidate.version)
+  version = int(version_match.group(0)) if version_match else 0
+  return (
+    candidate.managed_updated,
+    version,
+    candidate.metadata_hash,
+    -candidate.number,
+  )
+
+
+def _bibliography_identity(
+  works: Sequence[CanonicalWork],
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+  aliases: dict[str, set[str]] = {}
+  inputs: dict[str, set[str]] = {}
+  for work in works:
+    work_aliases = {
+      alias
+      for value in (work.work_id, *work.identifiers)
+      if (alias := normalize_alias(str(value)))
+    }
+    title_alias = strict_title_alias(
+      work.title, str(work.fields.get("author") or ""), work.year
+    )
+    if title_alias:
+      work_aliases.add(title_alias)
+    for alias in work_aliases:
+      aliases.setdefault(alias, set()).add(work.citekey)
+    inputs.setdefault(
+      embedding_input_hash(work.title, work.abstract), set()
+    ).add(work.citekey)
+  return aliases, inputs
+
+
+def _fixed_negative_identity(
+  path: Path,
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+  aliases: dict[str, set[str]] = {}
+  inputs: dict[str, set[str]] = {}
+  if not path.exists():
+    return aliases, inputs
+  for line_number, line in enumerate(
+    path.read_text(encoding="utf-8").splitlines(), 1
+  ):
+    if not line.strip():
+      continue
+    payload = json.loads(line)
+    if not isinstance(payload, Mapping):
+      raise ValueError(
+        f"Expected an object at {path.name}:{line_number}"
+      )
+    fixed_id = str(
+      payload.get("work_id") or payload.get("paper_id") or ""
+    ).strip()
+    if not fixed_id:
+      raise ValueError(
+        f"Fixed negative at {path.name}:{line_number} has no work identity"
+      )
+    row_aliases: set[str] = set()
+    for value in (
+      payload.get("work_id"),
+      payload.get("paper_id"),
+      f"pmid:{payload.get('pmid')}" if payload.get("pmid") else "",
+      f"doi:{payload.get('doi')}" if payload.get("doi") else "",
+      f"arxiv:{payload.get('arxiv_id')}" if payload.get("arxiv_id") else "",
+      *(payload.get("aliases") or []),
+    ):
+      if alias := normalize_alias(str(value or "")):
+        row_aliases.add(alias)
+    title = str(payload.get("title") or "").strip()
+    abstract = str(payload.get("abstract") or "").strip()
+    if title and abstract:
+      inputs.setdefault(embedding_input_hash(title, abstract), set()).add(
+        fixed_id
+      )
+    authors = payload.get("authors") or []
+    author_text = (
+      " and ".join(str(author) for author in authors)
+      if isinstance(authors, list)
+      else str(authors)
+    )
+    title_alias = strict_title_alias(
+      title, author_text, str(payload.get("published_year") or "")
+    )
+    if title_alias:
+      row_aliases.add(title_alias)
+    for alias in row_aliases:
+      aliases.setdefault(alias, set()).add(fixed_id)
+  return aliases, inputs
+
+
+def strict_title_alias(title: str, authors: str, year: str) -> str:
+  """Return the title/first-author/year alias used for strict work matching."""
+
+  normalized_title = normalize_title(title)
+  author_items = tuple(
+    item.strip()
+    for item in re.split(r"\s+and\s+", authors, flags=re.IGNORECASE)
+    if item.strip()
+  )
+  author = first_author_key(author_items)
+  year_match = re.search(r"(?:19|20)\d{2}", year)
+  if not normalized_title or not author or year_match is None:
+    return ""
+  digest = hashlib.sha256(
+    f"{normalized_title}\0{author}\0{year_match.group(0)}".encode("utf-8")
+  ).hexdigest()[:24]
+  return f"title:{digest}"
+
+
+def _write_snapshot(
+  path: Path, records: Iterable[IssueNegativeRecord]
+) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  content = "".join(
+    json.dumps(
+      record.to_dict(),
+      ensure_ascii=False,
+      sort_keys=True,
+      separators=(",", ":"),
+    )
+    + "\n"
+    for record in records
+  )
+  descriptor, temporary_name = tempfile.mkstemp(
+    prefix=f".{path.name}.", dir=path.parent
+  )
+  temporary = Path(temporary_name)
+  try:
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+      handle.write(content)
+      handle.flush()
+      os.fsync(handle.fileno())
+    os.replace(temporary, path)
+  finally:
+    if temporary.exists():
+      temporary.unlink()
+
+
+__all__ = [
+  "ISSUE_NEGATIVE_CORPUS",
+  "ISSUE_NEGATIVE_MANIFEST",
+  "ISSUE_NEGATIVE_MATRIX",
+  "ISSUE_NEGATIVE_SCHEMA",
+  "IssueNegativeRecord",
+  "load_issue_negative_snapshot",
+  "strict_title_alias",
+  "sync_issue_negatives",
+]

--- a/scripts/paperbot/model.py
+++ b/scripts/paperbot/model.py
@@ -44,6 +44,14 @@ from .negative_policy import (
   TARGET_TEXT_RE,
   is_target_topic,
 )
+from .issue_negatives import (
+  ISSUE_NEGATIVE_CORPUS,
+  ISSUE_NEGATIVE_MANIFEST,
+  ISSUE_NEGATIVE_MATRIX,
+  IssueNegativeRecord,
+  load_issue_negative_snapshot,
+  strict_title_alias,
+)
 
 
 BASE_MODEL = "allenai/specter2_base"
@@ -76,6 +84,7 @@ MODEL_MANIFEST = "model_manifest.json"
 NEGATIVE_CORPUS_SOURCE = "PubMed/MEDLINE"
 NEGATIVE_METADATA_SOURCE = "PubMed/MEDLINE via NCBI E-utilities"
 NEGATIVE_MANIFEST_SOURCE = "pubmed"
+ISSUE_NEGATIVE_POLICY_VERSION = 1
 SHA256_RE = re.compile(r"[0-9a-f]{64}")
 # Retained as a public compatibility alias for tests and audit tooling.  The
 # PubMed corpus intentionally blocks only explicit target-field phrases; a
@@ -606,10 +615,28 @@ def refresh_model(
   artifacts.mkdir(parents=True, exist_ok=True)
   negative_path = Path(negatives_path) if negatives_path else artifacts / NEGATIVE_CORPUS
   negative_metadata_path = negative_path.with_name(NEGATIVE_METADATA)
+  issue_negative_path = artifacts / ISSUE_NEGATIVE_CORPUS
   exceptions = load_title_only_exceptions(title_only_exceptions_path)
   works = canonicalize_entries(load_bibliography(bibliography_path))
   require_abstracts(works, exceptions)
   negatives = load_negative_corpus(negative_path)
+  issue_negative_snapshot = load_issue_negative_snapshot(issue_negative_path)
+  issue_negative_items, issue_negative_stats = _issue_negative_items(
+    issue_negative_snapshot,
+    works,
+    negatives,
+  )
+  issue_negative_training_hash = _issue_negative_training_hash(
+    issue_negative_items
+  )
+  issue_negative_snapshot_records = _issue_negative_snapshot_records(
+    issue_negative_snapshot
+  )
+  issue_negative_snapshot_file_hash = (
+    _file_hash(issue_negative_path)
+    if issue_negative_path.exists()
+    else hashlib.sha256(b"").hexdigest()
+  )
   negative_corpus_file_hash = _file_hash(negative_path)
   corpus_errors = validate_positive_negative_overlap(works, negatives)
   if strict_negative_quotas:
@@ -620,9 +647,11 @@ def refresh_model(
   negative_metadata_file_hash = (
     _file_hash(negative_metadata_path) if negative_metadata_path.exists() else ""
   )
-  if len(works) > len(negatives) * 1.25:
+  effective_negative_count = len(negatives) + len(issue_negative_items)
+  if len(works) > effective_negative_count * 1.25:
     warnings.warn(
-      f"Positive corpus ({len(works)}) exceeds fixed negatives ({len(negatives)}) by more than 25%",
+      f"Positive corpus ({len(works)}) exceeds effective negatives "
+      f"({effective_negative_count}) by more than 25%",
       RuntimeWarning,
       stacklevel=2,
     )
@@ -661,6 +690,9 @@ def refresh_model(
   reuse_embeddings = _verify_reusable_embedding_artifacts(
     artifacts, old_model_manifest
   )
+  reuse_issue_embeddings = _verify_reusable_issue_embedding_artifacts(
+    artifacts, old_model_manifest
+  )
 
   encoder = encoder or Specter2Encoder()
   positive_items = [_positive_item(work, exceptions, abstract_provenance or {}) for work in works]
@@ -688,10 +720,26 @@ def refresh_model(
     retain_removed=False,
     reuse_existing=reuse_embeddings,
   )
+  issue_negative_matrix, issue_negative_manifest = _refresh_embedding_matrix(
+    issue_negative_items,
+    artifacts / ISSUE_NEGATIVE_MATRIX,
+    artifacts / ISSUE_NEGATIVE_MANIFEST,
+    encoder,
+    retain_removed=True,
+    reuse_existing=reuse_issue_embeddings,
+  )
 
   positive_active = _active_matrix(positive_matrix, positive_manifest)
   negative_active = _active_matrix(negative_matrix, negative_manifest)
-  coefficients, intercept, training = fit_logistic_regression(positive_active, negative_active)
+  issue_negative_active = _active_matrix(
+    issue_negative_matrix, issue_negative_manifest
+  )
+  effective_negative = _combine_negative_matrices(
+    negative_active, issue_negative_active
+  )
+  coefficients, intercept, training = fit_logistic_regression(
+    positive_active, effective_negative
+  )
 
   semantic_hash = semantic_bibliography_hash(works, exceptions)
   classifier_payload = {
@@ -705,6 +753,7 @@ def refresh_model(
     semantic_hash,
     negative_corpus_file_hash,
     negative_metadata_file_hash,
+    issue_negative_training_hash,
   )
   manifest: dict[str, Any] = {
     "schema": ARTIFACT_SCHEMA,
@@ -726,6 +775,31 @@ def refresh_model(
     "negative_count": len(negative_items),
     "negative_manifest_hash": _records_hash(negative_manifest),
     "negative_matrix_hash": _array_hash(negative_matrix),
+    "issue_negative_corpus": ISSUE_NEGATIVE_CORPUS,
+    "issue_negative_policy_version": ISSUE_NEGATIVE_POLICY_VERSION,
+    "issue_negative_snapshot_count": issue_negative_stats["snapshot_count"],
+    "issue_negative_collector_included_count": issue_negative_stats[
+      "collector_included_count"
+    ],
+    "issue_negative_count": issue_negative_stats["active_count"],
+    "issue_negative_omitted_count": issue_negative_stats["omitted_count"],
+    "issue_negative_bibliography_overlap_count": issue_negative_stats[
+      "bibliography_overlap_count"
+    ],
+    "issue_negative_fixed_overlap_count": issue_negative_stats[
+      "fixed_overlap_count"
+    ],
+    "issue_negative_omission_counts": issue_negative_stats["omission_counts"],
+    "issue_negative_snapshot_hash": _records_hash(
+      issue_negative_snapshot_records
+    ),
+    "issue_negative_snapshot_file_hash": issue_negative_snapshot_file_hash,
+    "issue_negative_corpus_hash": _records_hash(issue_negative_items),
+    "issue_negative_training_hash": issue_negative_training_hash,
+    "issue_negative_rows": len(issue_negative_manifest),
+    "issue_negative_manifest_hash": _records_hash(issue_negative_manifest),
+    "issue_negative_matrix_hash": _array_hash(issue_negative_matrix),
+    "effective_negative_count": effective_negative_count,
     "model_hash": model_hash,
     "training": training,
     "dependencies": _dependency_versions(),
@@ -734,6 +808,12 @@ def refresh_model(
   _atomic_write_jsonl(artifacts / POSITIVE_MANIFEST, positive_manifest)
   _atomic_save_npy(artifacts / NEGATIVE_MATRIX, negative_matrix)
   _atomic_write_jsonl(artifacts / NEGATIVE_MANIFEST, negative_manifest)
+  if not issue_negative_path.exists():
+    _atomic_write_jsonl(issue_negative_path, issue_negative_snapshot_records)
+  _atomic_save_npy(artifacts / ISSUE_NEGATIVE_MATRIX, issue_negative_matrix)
+  _atomic_write_jsonl(
+    artifacts / ISSUE_NEGATIVE_MANIFEST, issue_negative_manifest
+  )
   _atomic_save_npz(artifacts / CLASSIFIER_FILE, classifier_payload)
   _atomic_write_json(artifacts / MODEL_MANIFEST, manifest)
   return manifest
@@ -781,6 +861,200 @@ def _negative_item(paper: NegativePaper) -> dict[str, Any]:
     "academic_graph": paper.metadata.get("academic_graph", {}),
     "_abstract": paper.abstract,
   }
+
+
+def _identity_aliases(value: Any) -> set[str]:
+  """Return conservative normalized identity aliases for overlap checks."""
+
+  raw = str(value or "").strip().casefold()
+  if not raw:
+    return set()
+  aliases = {raw}
+  doi_value = raw.removeprefix("doi:")
+  doi = normalize_doi(doi_value)
+  if doi.startswith("10.") and "/" in doi:
+    aliases.add(f"doi:{doi}")
+  if raw.startswith("pmid:"):
+    pmid = raw.removeprefix("pmid:").strip()
+    if pmid:
+      aliases.add(f"pmid:{pmid}")
+  return aliases
+
+
+def _work_identities(work: CanonicalWork) -> set[str]:
+  identities: set[str] = set()
+  for value in (work.work_id, *work.identifiers):
+    identities.update(_identity_aliases(value))
+  title_alias = strict_title_alias(
+    work.title,
+    str(work.fields.get("author") or ""),
+    work.year,
+  )
+  identities.update(_identity_aliases(title_alias))
+  return identities
+
+
+def _fixed_negative_identities(paper: NegativePaper) -> set[str]:
+  identities = _identity_aliases(paper.paper_id)
+  for key, prefix in (
+    ("pmid", "pmid:"),
+    ("doi", "doi:"),
+    ("arxiv_id", "arxiv:"),
+    ("provider_id", ""),
+    ("source_id", ""),
+  ):
+    value = str(paper.metadata.get(key) or "").strip()
+    if value:
+      identities.update(_identity_aliases(f"{prefix}{value}"))
+  authors = paper.metadata.get("authors") or []
+  author_text = (
+    " and ".join(str(author) for author in authors)
+    if isinstance(authors, list)
+    else str(authors)
+  )
+  title_alias = strict_title_alias(
+    paper.title,
+    author_text,
+    str(paper.published_year),
+  )
+  identities.update(_identity_aliases(title_alias))
+  return identities
+
+
+def _issue_negative_items(
+  snapshot: Sequence[IssueNegativeRecord],
+  works: Sequence[CanonicalWork],
+  fixed_negatives: Sequence[NegativePaper],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+  """Build the effective issue-negative corpus and fail closed on duplicates.
+
+  The collector owns issue selection and canonicalization. This second check is
+  intentionally independent: a paper that has since entered the bibliography,
+  or one already represented by the frozen corpus, must never receive negative
+  training weight even if an old snapshot still marks it as included.
+  """
+
+  positive_ids = set().union(*(_work_identities(work) for work in works)) if works else set()
+  positive_inputs = {
+    embedding_input_hash(work.title, work.abstract) for work in works
+  }
+  fixed_ids = (
+    set().union(*(_fixed_negative_identities(paper) for paper in fixed_negatives))
+    if fixed_negatives else set()
+  )
+  fixed_inputs = {
+    embedding_input_hash(paper.title, paper.abstract) for paper in fixed_negatives
+  }
+
+  seen_work_ids: set[str] = set()
+  seen_aliases: dict[str, str] = {}
+  seen_issue_numbers: dict[int, str] = {}
+  seen_active_inputs: dict[str, str] = {}
+  items: list[dict[str, Any]] = []
+  omission_counts: dict[str, int] = {}
+  collector_included_count = 0
+
+  for record in snapshot:
+    work_id = record.work_id
+    title = record.title
+    abstract = record.abstract
+    input_hash = record.input_hash
+    normalized_work_id = work_id.casefold()
+    if normalized_work_id in seen_work_ids:
+      raise ValueError(f"Duplicate issue-negative work identity: {work_id}")
+    seen_work_ids.add(normalized_work_id)
+    row_ids = _identity_aliases(work_id)
+    for alias in record.aliases:
+      row_ids.update(_identity_aliases(alias))
+    for identity in sorted(row_ids):
+      previous = seen_aliases.get(identity)
+      if previous is not None:
+        raise ValueError(
+          f"Duplicate issue-negative identity {identity}: {previous} and {work_id}"
+        )
+      seen_aliases[identity] = work_id
+    for issue_number in record.issue_numbers:
+      previous = seen_issue_numbers.get(issue_number)
+      if previous is not None:
+        raise ValueError(
+          f"GitHub issue #{issue_number} appears in issue-negative works "
+          f"{previous} and {work_id}"
+        )
+      seen_issue_numbers[issue_number] = work_id
+
+    effective_included = record.active
+    effective_reasons = set(record.omission_reasons)
+    if effective_included:
+      collector_included_count += 1
+      if (
+        row_ids & positive_ids
+        or input_hash in positive_inputs
+      ):
+        effective_included = False
+        effective_reasons.add("bibliography_overlap")
+      elif (
+        row_ids & fixed_ids
+        or input_hash in fixed_inputs
+      ):
+        effective_included = False
+        effective_reasons.add("fixed_negative_overlap")
+
+    if not effective_included:
+      for reason in sorted(effective_reasons):
+        omission_counts[reason] = omission_counts.get(reason, 0) + 1
+      continue
+    previous_input = seen_active_inputs.get(input_hash)
+    if previous_input is not None:
+      raise ValueError(
+        f"Duplicate issue-negative embedding input: {previous_input} and {work_id}"
+      )
+    seen_active_inputs[input_hash] = work_id
+    items.append({
+      "work_id": work_id,
+      "aliases": list(record.aliases),
+      "issue_numbers": list(record.issue_numbers),
+      "issue_urls": list(record.issue_urls),
+      "selected_issue_number": record.selected_issue_number,
+      "title": title,
+      "abstract_hash": hashlib.sha256(abstract.encode("utf-8")).hexdigest(),
+      "input_hash": input_hash,
+      "metadata_hash": record.metadata_hash,
+      "source": "github_issues",
+      "active_snapshot": True,
+      "_abstract": abstract,
+    })
+
+  stats = {
+    "snapshot_count": len(snapshot),
+    "collector_included_count": collector_included_count,
+    "active_count": len(items),
+    "omitted_count": len(snapshot) - len(items),
+    "bibliography_overlap_count": omission_counts.get("bibliography_overlap", 0),
+    "fixed_overlap_count": omission_counts.get("fixed_negative_overlap", 0),
+    "omission_counts": dict(sorted(omission_counts.items())),
+  }
+  return items, stats
+
+
+def _issue_negative_snapshot_records(
+  snapshot: Sequence[IssueNegativeRecord],
+) -> list[dict[str, Any]]:
+  """Return the collector snapshot's stable public representation."""
+
+  return [record.to_dict() for record in snapshot]
+
+
+def _issue_negative_training_hash(
+  items: Sequence[Mapping[str, Any]],
+) -> str:
+  """Hash only inputs that can affect the fitted classifier."""
+
+  return _records_hash(
+    sorted(
+      ({"input_hash": str(item["input_hash"])} for item in items),
+      key=lambda item: item["input_hash"],
+    )
+  )
 
 
 def _item_id(item: Mapping[str, Any]) -> str:
@@ -864,7 +1138,7 @@ def _refresh_embedding_matrix(
 
 def _manifest_item(item: Mapping[str, Any], previous: Mapping[str, Any] | None) -> dict[str, Any]:
   public = _public_item(item)
-  if "work_id" not in public:
+  if "citekey" not in public:
     return public
   for field in (
     "abstract_source",
@@ -883,6 +1157,15 @@ def _active_matrix(matrix: Any, manifest: Sequence[Mapping[str, Any]]) -> Any:
   np = _numpy()
   indexes = [int(row["row"]) for row in manifest if row.get("active", True)]
   return np.asarray(matrix[indexes], dtype=np.float32)
+
+
+def _combine_negative_matrices(fixed: Any, issue_feedback: Any) -> Any:
+  np = _numpy()
+  _validate_matrix(fixed, len(fixed), "fixed negative matrix")
+  _validate_matrix(issue_feedback, len(issue_feedback), "issue-negative matrix")
+  return np.concatenate([fixed, issue_feedback], axis=0).astype(
+    np.float32, copy=False
+  )
 
 
 def fit_logistic_regression(positive: Any, negative: Any) -> tuple[Any, float, dict[str, Any]]:
@@ -961,10 +1244,38 @@ def model_errors(
   try:
     np = _numpy()
     manifest = json.loads((artifacts / MODEL_MANIFEST).read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+      raise ValueError("model manifest is not a JSON object")
+  except Exception as error:
+    return [f"could not safely load artifacts: {error}"]
+
+  has_issue_feedback = any(
+    str(field).startswith("issue_negative_") for field in manifest
+  )
+  if has_issue_feedback:
+    issue_paths = [
+      artifacts / ISSUE_NEGATIVE_CORPUS,
+      artifacts / ISSUE_NEGATIVE_MATRIX,
+      artifacts / ISSUE_NEGATIVE_MANIFEST,
+    ]
+    missing = [path.name for path in issue_paths if not path.exists()]
+    if missing:
+      return [f"missing artifact: {name}" for name in missing]
+  try:
     positive_manifest = _read_jsonl(artifacts / POSITIVE_MANIFEST)
     negative_manifest = _read_jsonl(artifacts / NEGATIVE_MANIFEST)
     positive_matrix = _load_npy(artifacts / POSITIVE_MATRIX)
     negative_matrix = _load_npy(artifacts / NEGATIVE_MATRIX)
+    if has_issue_feedback:
+      issue_negative_manifest = _read_jsonl(
+        artifacts / ISSUE_NEGATIVE_MANIFEST
+      )
+      issue_negative_matrix = _load_npy(artifacts / ISSUE_NEGATIVE_MATRIX)
+    else:
+      issue_negative_manifest = []
+      issue_negative_matrix = np.empty(
+        (0, EMBEDDING_DIMENSION), dtype=np.float32
+      )
     with np.load(artifacts / CLASSIFIER_FILE, allow_pickle=False) as model:
       coefficients = np.asarray(model["coef"], dtype=np.float64)
       intercept = float(np.asarray(model["intercept"])[0])
@@ -991,12 +1302,22 @@ def model_errors(
     "negative_graph_provider": SEMANTIC_SCHOLAR_PROVIDER,
     "negative_metadata": NEGATIVE_METADATA,
   }
+  if has_issue_feedback:
+    expected_negative_fields.update({
+      "issue_negative_corpus": ISSUE_NEGATIVE_CORPUS,
+      "issue_negative_policy_version": ISSUE_NEGATIVE_POLICY_VERSION,
+    })
   for field, expected in expected_negative_fields.items():
     if manifest.get(field) != expected:
       errors.append(f"model manifest {field} is invalid")
   try:
     _validate_matrix(positive_matrix, len(positive_manifest), "positive matrix")
     _validate_matrix(negative_matrix, len(negative_manifest), "negative matrix")
+    _validate_matrix(
+      issue_negative_matrix,
+      len(issue_negative_manifest),
+      "issue-negative matrix",
+    )
   except ValueError as error:
     errors.append(str(error))
   if coefficients.shape != (EMBEDDING_DIMENSION,):
@@ -1006,7 +1327,10 @@ def model_errors(
   try:
     refit_coefficients, refit_intercept, refit_training = fit_logistic_regression(
       _active_matrix(positive_matrix, positive_manifest),
-      _active_matrix(negative_matrix, negative_manifest),
+      _combine_negative_matrices(
+        _active_matrix(negative_matrix, negative_manifest),
+        _active_matrix(issue_negative_matrix, issue_negative_manifest),
+      ),
     )
     if not np.allclose(coefficients, refit_coefficients, rtol=1e-10, atol=1e-12):
       errors.append("stored classifier coefficients do not match a deterministic refit")
@@ -1127,8 +1451,107 @@ def model_errors(
   except Exception as error:
     errors.append(f"could not validate negative corpus: {error}")
     negative_items = []
+    negatives = []
     negative_corpus_file_hash = ""
     negative_metadata_file_hash = ""
+
+  issue_negative_path = artifacts / ISSUE_NEGATIVE_CORPUS
+  issue_negative_items: list[dict[str, Any]] = []
+  issue_negative_corpus_hash = _records_hash(issue_negative_items)
+  issue_negative_training_hash = _issue_negative_training_hash(
+    issue_negative_items
+  )
+  if has_issue_feedback:
+    try:
+      issue_negative_snapshot = load_issue_negative_snapshot(issue_negative_path)
+      issue_negative_snapshot_records = _issue_negative_snapshot_records(
+        issue_negative_snapshot
+      )
+      issue_negative_items, issue_negative_stats = _issue_negative_items(
+        issue_negative_snapshot,
+        works,
+        negatives,
+      )
+      issue_negative_corpus_hash = _records_hash(issue_negative_items)
+      issue_negative_training_hash = _issue_negative_training_hash(
+        issue_negative_items
+      )
+      active_issue_rows = [
+        row for row in issue_negative_manifest if row.get("active", True)
+      ]
+      actual_issue_by_id = {
+        _item_id(row): row for row in active_issue_rows
+      }
+      expected_issue_by_id = {
+        _item_id(item): item for item in issue_negative_items
+      }
+      if len(actual_issue_by_id) != len(active_issue_rows):
+        errors.append(
+          "issue-negative manifest contains duplicate active work identifiers"
+        )
+      if set(actual_issue_by_id) != set(expected_issue_by_id):
+        errors.append(
+          "active issue-negative embedding rows do not match the issue snapshot"
+        )
+      else:
+        core_fields = (
+          "aliases",
+          "issue_numbers",
+          "issue_urls",
+          "selected_issue_number",
+          "title",
+          "abstract_hash",
+          "input_hash",
+          "metadata_hash",
+          "source",
+          "active_snapshot",
+        )
+        stale_issue_rows = [
+          work_id
+          for work_id, item in expected_issue_by_id.items()
+          if any(
+            actual_issue_by_id[work_id].get(field) != item.get(field)
+            for field in core_fields
+          )
+        ]
+        if stale_issue_rows:
+          errors.append(
+            "issue-negative manifest or embeddings are stale for "
+            f"{len(stale_issue_rows)} works"
+          )
+
+      issue_checks = {
+        "issue_negative_snapshot_count": issue_negative_stats["snapshot_count"],
+        "issue_negative_collector_included_count": issue_negative_stats[
+          "collector_included_count"
+        ],
+        "issue_negative_count": issue_negative_stats["active_count"],
+        "issue_negative_omitted_count": issue_negative_stats["omitted_count"],
+        "issue_negative_bibliography_overlap_count": issue_negative_stats[
+          "bibliography_overlap_count"
+        ],
+        "issue_negative_fixed_overlap_count": issue_negative_stats[
+          "fixed_overlap_count"
+        ],
+        "issue_negative_omission_counts": issue_negative_stats[
+          "omission_counts"
+        ],
+        "issue_negative_snapshot_hash": _records_hash(
+          issue_negative_snapshot_records
+        ),
+        "issue_negative_snapshot_file_hash": _file_hash(issue_negative_path),
+        "issue_negative_corpus_hash": issue_negative_corpus_hash,
+        "issue_negative_training_hash": issue_negative_training_hash,
+        "issue_negative_rows": len(issue_negative_manifest),
+        "effective_negative_count": (
+          len(negative_items) + len(issue_negative_items)
+        ),
+      }
+      for field, expected in issue_checks.items():
+        if manifest.get(field) != expected:
+          errors.append(f"model manifest {field} does not match issue feedback")
+    except Exception as error:
+      errors.append(f"could not validate issue-negative corpus: {error}")
 
   checks = {
     "positive_manifest_hash": _records_hash(positive_manifest),
@@ -1136,6 +1559,11 @@ def model_errors(
     "negative_manifest_hash": _records_hash(negative_manifest),
     "negative_matrix_hash": _array_hash(negative_matrix),
   }
+  if has_issue_feedback:
+    checks.update({
+      "issue_negative_manifest_hash": _records_hash(issue_negative_manifest),
+      "issue_negative_matrix_hash": _array_hash(issue_negative_matrix),
+    })
   for name, actual in checks.items():
     if manifest.get(name) != actual:
       errors.append(f"{name} does not match its artifact")
@@ -1145,6 +1573,7 @@ def model_errors(
     expected_hash,
     negative_corpus_file_hash,
     negative_metadata_file_hash,
+    issue_negative_training_hash if has_issue_feedback else None,
   )
   if manifest.get("model_hash") != expected_model_hash:
     errors.append("classifier/model hash does not match")
@@ -1295,12 +1724,52 @@ def _verify_reusable_embedding_artifacts(
   return True
 
 
+def _verify_reusable_issue_embedding_artifacts(
+  artifacts: Path,
+  old_model_manifest: Mapping[str, Any],
+) -> bool:
+  """Independently validate reusable human-feedback embedding rows."""
+
+  matrix_path = artifacts / ISSUE_NEGATIVE_MATRIX
+  manifest_path = artifacts / ISSUE_NEGATIVE_MANIFEST
+  expected_matrix_hash = old_model_manifest.get("issue_negative_matrix_hash")
+  expected_manifest_hash = old_model_manifest.get("issue_negative_manifest_hash")
+  if (
+    old_model_manifest.get("schema") != ARTIFACT_SCHEMA
+    or old_model_manifest.get("embedding") != EMBEDDING_CONFIG
+    or not isinstance(expected_matrix_hash, str)
+    or SHA256_RE.fullmatch(expected_matrix_hash) is None
+    or not isinstance(expected_manifest_hash, str)
+    or SHA256_RE.fullmatch(expected_manifest_hash) is None
+    or not matrix_path.exists()
+    or not manifest_path.exists()
+  ):
+    return False
+  try:
+    matrix_hash = _array_hash(_load_npy(matrix_path))
+    manifest_hash = _records_hash(_read_jsonl(manifest_path))
+  except Exception as error:
+    raise ValueError(
+      f"Cannot safely reuse issue-negative embedding artifacts: {error}"
+    ) from error
+  if (
+    matrix_hash != expected_matrix_hash
+    or manifest_hash != expected_manifest_hash
+  ):
+    raise ValueError(
+      "Refusing to reuse corrupt issue-negative embedding artifacts; "
+      "restore or rebuild them explicitly"
+    )
+  return True
+
+
 def _model_hash(
   coefficients: Any,
   intercept: float,
   bibliography_hash: str,
   negative_hash: str,
   negative_metadata_hash: str,
+  issue_negative_hash: str | None = None,
 ) -> str:
   np = _numpy()
   digest = hashlib.sha256()
@@ -1309,6 +1778,8 @@ def _model_hash(
   digest.update(bibliography_hash.encode("ascii"))
   digest.update(negative_hash.encode("ascii"))
   digest.update(negative_metadata_hash.encode("ascii"))
+  if issue_negative_hash is not None:
+    digest.update(issue_negative_hash.encode("ascii"))
   digest.update(BASE_REVISION.encode("ascii"))
   digest.update(CLASSIFICATION_ADAPTER_REVISION.encode("ascii"))
   digest.update(json.dumps(CLASSIFIER_CONFIG, separators=(",", ":"), sort_keys=True).encode("ascii"))

--- a/scripts/paperbot/model.py
+++ b/scripts/paperbot/model.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Protocol, Sequence
 
 from .bibliography import (
+  BibliographyEntry,
   CanonicalWork,
   canonicalize_entries,
   embedding_input_hash,
@@ -53,6 +54,7 @@ from .issue_negatives import (
   load_issue_negative_snapshot,
   strict_title_alias,
 )
+from .records import normalize_title as normalize_record_title
 
 
 BASE_MODEL = "allenai/specter2_base"
@@ -617,8 +619,14 @@ def refresh_model(
   negative_path = Path(negatives_path) if negatives_path else artifacts / NEGATIVE_CORPUS
   negative_metadata_path = negative_path.with_name(NEGATIVE_METADATA)
   issue_negative_path = artifacts / ISSUE_NEGATIVE_CORPUS
+  if not issue_negative_path.exists():
+    raise ValueError(
+      "The synchronized issue-negative snapshot is missing; "
+      "run sync-issue-negatives before refreshing the model"
+    )
   exceptions = load_title_only_exceptions(title_only_exceptions_path)
-  works = canonicalize_entries(load_bibliography(bibliography_path))
+  bibliography_entries = load_bibliography(bibliography_path)
+  works = canonicalize_entries(bibliography_entries)
   require_abstracts(works, exceptions)
   negatives = load_negative_corpus(negative_path)
   issue_negative_snapshot = load_issue_negative_snapshot(issue_negative_path)
@@ -626,6 +634,7 @@ def refresh_model(
     issue_negative_snapshot,
     works,
     negatives,
+    bibliography_entries,
   )
   issue_negative_training_hash = _issue_negative_training_hash(
     issue_negative_items
@@ -823,8 +832,6 @@ def refresh_model(
   _atomic_write_jsonl(artifacts / POSITIVE_MANIFEST, positive_manifest)
   _atomic_save_npy(artifacts / NEGATIVE_MATRIX, negative_matrix)
   _atomic_write_jsonl(artifacts / NEGATIVE_MANIFEST, negative_manifest)
-  if not issue_negative_path.exists():
-    _atomic_write_jsonl(issue_negative_path, issue_negative_snapshot_records)
   _atomic_save_npy(artifacts / ISSUE_NEGATIVE_MATRIX, issue_negative_matrix)
   _atomic_write_jsonl(
     artifacts / ISSUE_NEGATIVE_MANIFEST, issue_negative_manifest
@@ -936,10 +943,70 @@ def _fixed_negative_identities(paper: NegativePaper) -> set[str]:
   return identities
 
 
+def _issue_overlap_provenance(
+  record: IssueNegativeRecord,
+  works: Sequence[CanonicalWork],
+  fixed_negatives: Sequence[NegativePaper],
+  bibliography_entries: Sequence[BibliographyEntry],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+  """Recompute exact current overlap provenance from carried component data."""
+
+  row_ids = _identity_aliases(record.work_id)
+  for alias in record.aliases:
+    row_ids.update(_identity_aliases(alias))
+  component_titles = set(record.component_titles) or {
+    normalize_record_title(record.title)
+  }
+  component_inputs = set(record.component_input_hashes) or {
+    record.input_hash
+  }
+  known_bib_keys = set(record.known_bib_keys)
+
+  bibliography_keys: set[str] = set()
+  for work in works:
+    identity_match = bool(row_ids & _work_identities(work))
+    title_match = normalize_record_title(work.title) in component_titles
+    input_match = (
+      embedding_input_hash(work.title, work.abstract) in component_inputs
+    )
+    if identity_match or title_match or input_match:
+      bibliography_keys.add(work.citekey)
+    bibliography_keys.update(known_bib_keys & set(work.aliases))
+  owner_by_key = {
+    alias: work.citekey
+    for work in works
+    for alias in work.aliases
+  }
+  for entry in bibliography_entries:
+    if (
+      normalize_record_title(entry.title) in component_titles
+      or (
+        bool(entry.abstract)
+        and embedding_input_hash(entry.title, entry.abstract)
+        in component_inputs
+      )
+    ):
+      bibliography_keys.add(owner_by_key.get(entry.key, entry.key))
+
+  fixed_negative_ids: set[str] = set()
+  for paper in fixed_negatives:
+    fixed_id = str(
+      paper.metadata.get("work_id") or paper.paper_id
+    ).strip()
+    if (
+      row_ids & _fixed_negative_identities(paper)
+      or normalize_record_title(paper.title) in component_titles
+      or embedding_input_hash(paper.title, paper.abstract) in component_inputs
+    ):
+      fixed_negative_ids.add(fixed_id)
+  return tuple(sorted(bibliography_keys)), tuple(sorted(fixed_negative_ids))
+
+
 def _issue_negative_items(
   snapshot: Sequence[IssueNegativeRecord],
   works: Sequence[CanonicalWork],
   fixed_negatives: Sequence[NegativePaper],
+  bibliography_entries: Sequence[BibliographyEntry],
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
   """Build the effective issue-negative corpus and fail closed on duplicates.
 
@@ -948,32 +1015,6 @@ def _issue_negative_items(
   or one already represented by the frozen corpus, must never receive negative
   training weight even if an old snapshot still marks it as included.
   """
-
-  positive_ids = set().union(*(_work_identities(work) for work in works)) if works else set()
-  # Stable identifiers and title/author/year aliases are the preferred match,
-  # but old issues can lack either one. An exact normalized title is a
-  # deliberately conservative final guard against teaching the classifier
-  # that a bibliography paper is negative after its abstract was revised.
-  positive_titles = {
-    normalized
-    for work in works
-    if (normalized := normalize_title(work.title))
-  }
-  positive_inputs = {
-    embedding_input_hash(work.title, work.abstract) for work in works
-  }
-  fixed_ids = (
-    set().union(*(_fixed_negative_identities(paper) for paper in fixed_negatives))
-    if fixed_negatives else set()
-  )
-  fixed_inputs = {
-    embedding_input_hash(paper.title, paper.abstract) for paper in fixed_negatives
-  }
-  fixed_titles = {
-    normalized
-    for paper in fixed_negatives
-    if (normalized := normalize_title(paper.title))
-  }
 
   seen_work_ids: set[str] = set()
   seen_aliases: dict[str, str] = {}
@@ -1011,24 +1052,31 @@ def _issue_negative_items(
         )
       seen_issue_numbers[issue_number] = work_id
 
-    effective_included = record.active
-    effective_reasons = set(record.omission_reasons)
-    if effective_included:
+    bibliography_keys, fixed_negative_ids = _issue_overlap_provenance(
+      record, works, fixed_negatives, bibliography_entries
+    )
+    computed_reasons = tuple(
+      reason
+      for reason, applies in (
+        ("bibliography_overlap", bool(bibliography_keys)),
+        ("fixed_negative_overlap", bool(fixed_negative_ids)),
+      )
+      if applies
+    )
+    if not record.active and (
+      record.omission_reasons != computed_reasons
+      or record.bibliography_keys != bibliography_keys
+      or record.fixed_negative_ids != fixed_negative_ids
+    ):
+      raise ValueError(
+        f"Inactive issue-negative overlap provenance is stale or invalid for "
+        f"{work_id}"
+      )
+
+    effective_included = not computed_reasons
+    effective_reasons = set(computed_reasons)
+    if record.active:
       collector_included_count += 1
-      if (
-        row_ids & positive_ids
-        or normalize_title(title) in positive_titles
-        or input_hash in positive_inputs
-      ):
-        effective_included = False
-        effective_reasons.add("bibliography_overlap")
-      elif (
-        row_ids & fixed_ids
-        or normalize_title(title) in fixed_titles
-        or input_hash in fixed_inputs
-      ):
-        effective_included = False
-        effective_reasons.add("fixed_negative_overlap")
 
     if not effective_included:
       for reason in sorted(effective_reasons):
@@ -1046,6 +1094,9 @@ def _issue_negative_items(
       "issue_numbers": list(record.issue_numbers),
       "issue_urls": list(record.issue_urls),
       "selected_issue_number": record.selected_issue_number,
+      "known_bib_keys": list(record.known_bib_keys),
+      "component_titles": list(record.component_titles),
+      "component_input_hashes": list(record.component_input_hashes),
       "title": title,
       "abstract_hash": hashlib.sha256(abstract.encode("utf-8")).hexdigest(),
       "input_hash": input_hash,
@@ -1163,7 +1214,15 @@ def _refresh_embedding_matrix(
         row_index = len(rows)
         rows.append(old_matrix[int(previous["row"])].astype(np.float32, copy=True))
         manifest.append({**public_item, "row": row_index, "active": True})
-      if previous.get("input_hash") != item.get("input_hash"):
+      # ``input_hash`` intentionally uses a punctuation-insensitive title for
+      # identity matching. SPECTER2 receives the exact stripped title, so title
+      # formatting changes must independently invalidate a reusable vector.
+      previous_title = str(previous.get("title") or "").strip()
+      current_title = str(item.get("title") or "").strip()
+      if (
+        previous.get("input_hash") != item.get("input_hash")
+        or previous_title != current_title
+      ):
         pending.append(item)
         pending_rows.append(row_index)
     else:
@@ -1407,7 +1466,8 @@ def model_errors(
     errors.append(f"could not independently refit classifier: {error}")
 
   exceptions = load_title_only_exceptions(title_only_exceptions_path)
-  works = canonicalize_entries(load_bibliography(bibliography_path))
+  bibliography_entries = load_bibliography(bibliography_path)
+  works = canonicalize_entries(bibliography_entries)
   try:
     require_abstracts(works, exceptions)
   except ValueError as error:
@@ -1536,6 +1596,7 @@ def model_errors(
         issue_negative_snapshot,
         works,
         negatives,
+        bibliography_entries,
       )
       issue_negative_corpus_hash = _records_hash(issue_negative_items)
       issue_negative_training_hash = _issue_negative_training_hash(
@@ -1564,6 +1625,9 @@ def model_errors(
           "issue_numbers",
           "issue_urls",
           "selected_issue_number",
+          "known_bib_keys",
+          "component_titles",
+          "component_input_hashes",
           "title",
           "abstract_hash",
           "input_hash",
@@ -1902,14 +1966,14 @@ def _verify_reusable_embedding_artifacts(
       _validate_embedding_artifact(matrix, rows, f"{label} matrix")
       matrix_hash = _array_hash(matrix)
       manifest_hash = _records_hash(rows)
-    except Exception as error:
-      raise ValueError(
-        f"Refusing to reuse corrupt {label} embedding artifacts: {error}"
-      ) from error
+    except Exception:
+      # A prior refresh may have stopped between atomic per-file replacements.
+      # Rebuild all rows rather than making that partially written state
+      # permanently unrecoverable. ``check_model`` still rejects it until an
+      # explicit trusted refresh completes.
+      return False
     if matrix_hash != expected_matrix_hash or manifest_hash != expected_manifest_hash:
-      raise ValueError(
-        f"Refusing to reuse corrupt {label} embedding artifacts; restore or rebuild them explicitly"
-      )
+      return False
   return True
 
 
@@ -1944,18 +2008,13 @@ def _verify_reusable_issue_embedding_artifacts(
     _validate_embedding_artifact(matrix, rows, "issue-negative matrix")
     matrix_hash = _array_hash(matrix)
     manifest_hash = _records_hash(rows)
-  except Exception as error:
-    raise ValueError(
-      f"Refusing to reuse corrupt issue-negative embedding artifacts: {error}"
-    ) from error
+  except Exception:
+    return False
   if (
     matrix_hash != expected_matrix_hash
     or manifest_hash != expected_manifest_hash
   ):
-    raise ValueError(
-      "Refusing to reuse corrupt issue-negative embedding artifacts; "
-      "restore or rebuild them explicitly"
-    )
+    return False
   return True
 
 

--- a/scripts/paperbot/model.py
+++ b/scripts/paperbot/model.py
@@ -26,6 +26,7 @@ from .bibliography import (
   load_title_only_exceptions,
   normalize_abstract,
   normalize_doi,
+  normalize_title,
   require_abstracts,
   semantic_bibliography_hash,
 )
@@ -668,6 +669,20 @@ def refresh_model(
       # An invalid old manifest provides no trustworthy embedding provenance.
       # Rebuild every row below instead of interpreting old bytes as current.
       old_model_manifest = {}
+  prior_issue_feedback = any(
+    str(field).startswith("issue_negative_") for field in old_model_manifest
+  ) or any(
+    path.exists()
+    for path in (
+      artifacts / ISSUE_NEGATIVE_MATRIX,
+      artifacts / ISSUE_NEGATIVE_MANIFEST,
+    )
+  )
+  if prior_issue_feedback and not issue_negative_path.exists():
+    raise ValueError(
+      "The synchronized issue-negative snapshot is missing; "
+      "run sync-issue-negatives before refreshing the model"
+    )
   old_corpus_file_hash = old_model_manifest.get("negative_corpus_file_hash")
   if (
     old_corpus_file_hash
@@ -935,6 +950,15 @@ def _issue_negative_items(
   """
 
   positive_ids = set().union(*(_work_identities(work) for work in works)) if works else set()
+  # Stable identifiers and title/author/year aliases are the preferred match,
+  # but old issues can lack either one. An exact normalized title is a
+  # deliberately conservative final guard against teaching the classifier
+  # that a bibliography paper is negative after its abstract was revised.
+  positive_titles = {
+    normalized
+    for work in works
+    if (normalized := normalize_title(work.title))
+  }
   positive_inputs = {
     embedding_input_hash(work.title, work.abstract) for work in works
   }
@@ -944,6 +968,11 @@ def _issue_negative_items(
   )
   fixed_inputs = {
     embedding_input_hash(paper.title, paper.abstract) for paper in fixed_negatives
+  }
+  fixed_titles = {
+    normalized
+    for paper in fixed_negatives
+    if (normalized := normalize_title(paper.title))
   }
 
   seen_work_ids: set[str] = set()
@@ -988,12 +1017,14 @@ def _issue_negative_items(
       collector_included_count += 1
       if (
         row_ids & positive_ids
+        or normalize_title(title) in positive_titles
         or input_hash in positive_inputs
       ):
         effective_included = False
         effective_reasons.add("bibliography_overlap")
       elif (
         row_ids & fixed_ids
+        or normalize_title(title) in fixed_titles
         or input_hash in fixed_inputs
       ):
         effective_included = False
@@ -1065,6 +1096,25 @@ def _public_item(item: Mapping[str, Any]) -> dict[str, Any]:
   return {key: value for key, value in item.items() if not key.startswith("_")}
 
 
+def _json_contract_equal(value: Any, expected: Any) -> bool:
+  """Compare JSON values without Python's bool/int or int/float aliases."""
+
+  try:
+    return json.dumps(
+      value,
+      ensure_ascii=False,
+      sort_keys=True,
+      separators=(",", ":"),
+    ) == json.dumps(
+      expected,
+      ensure_ascii=False,
+      sort_keys=True,
+      separators=(",", ":"),
+    )
+  except (TypeError, ValueError):
+    return False
+
+
 def _refresh_embedding_matrix(
   items: Sequence[Mapping[str, Any]],
   matrix_path: Path,
@@ -1128,11 +1178,13 @@ def _refresh_embedding_matrix(
       encoder.embed([(str(item["title"]), str(item.get("_abstract", ""))) for item in pending]),
       dtype=np.float32,
     )
-    _validate_matrix(embedded, len(pending), "embedding backend output")
+    _validate_embedding_vectors(
+      embedded, len(pending), "embedding backend output"
+    )
     for row_index, vector in zip(pending_rows, embedded):
       rows[row_index] = vector
   matrix = np.asarray(rows, dtype=np.float32).reshape((-1, EMBEDDING_DIMENSION))
-  _validate_matrix(matrix, len(manifest), "embedding matrix")
+  _validate_embedding_artifact(matrix, manifest, "embedding matrix")
   return matrix, manifest
 
 
@@ -1252,12 +1304,17 @@ def model_errors(
   has_issue_feedback = any(
     str(field).startswith("issue_negative_") for field in manifest
   )
-  if has_issue_feedback:
-    issue_paths = [
-      artifacts / ISSUE_NEGATIVE_CORPUS,
-      artifacts / ISSUE_NEGATIVE_MATRIX,
-      artifacts / ISSUE_NEGATIVE_MANIFEST,
+  issue_paths = [
+    artifacts / ISSUE_NEGATIVE_CORPUS,
+    artifacts / ISSUE_NEGATIVE_MATRIX,
+    artifacts / ISSUE_NEGATIVE_MANIFEST,
+  ]
+  if not has_issue_feedback and any(path.exists() for path in issue_paths):
+    return [
+      "issue-negative artifacts exist beside a legacy model manifest; "
+      "refresh the model instead of ignoring synchronized feedback"
     ]
+  if has_issue_feedback:
     missing = [path.name for path in issue_paths if not path.exists()]
     if missing:
       return [f"missing artifact: {name}" for name in missing]
@@ -1276,20 +1333,24 @@ def model_errors(
       issue_negative_matrix = np.empty(
         (0, EMBEDDING_DIMENSION), dtype=np.float32
       )
-    with np.load(artifacts / CLASSIFIER_FILE, allow_pickle=False) as model:
-      coefficients = np.asarray(model["coef"], dtype=np.float64)
-      intercept = float(np.asarray(model["intercept"])[0])
-      classes = np.asarray(model["classes"])
+    coefficients, intercept, classes = _load_classifier_artifact(
+      artifacts / CLASSIFIER_FILE
+    )
   except Exception as error:
     return [f"could not safely load artifacts: {error}"]
 
   errors: list[str] = []
   embedding = manifest.get("embedding", {})
-  if embedding != EMBEDDING_CONFIG:
+  if not _json_contract_equal(embedding, EMBEDDING_CONFIG):
     errors.append("embedding specification does not exactly match the runtime")
-  if manifest.get("schema") != ARTIFACT_SCHEMA:
+  schema = manifest.get("schema")
+  if (
+    not isinstance(schema, int)
+    or isinstance(schema, bool)
+    or schema != ARTIFACT_SCHEMA
+  ):
     errors.append(f"artifact schema is {manifest.get('schema')!r}, expected {ARTIFACT_SCHEMA}")
-  if manifest.get("classifier") != CLASSIFIER_CONFIG:
+  if not _json_contract_equal(manifest.get("classifier"), CLASSIFIER_CONFIG):
     errors.append("classifier hyperparameters do not match the deterministic configuration")
   recorded_dependencies = manifest.get("dependencies")
   runtime_dependencies = _dependency_versions()
@@ -1311,11 +1372,15 @@ def model_errors(
     if manifest.get(field) != expected:
       errors.append(f"model manifest {field} is invalid")
   try:
-    _validate_matrix(positive_matrix, len(positive_manifest), "positive matrix")
-    _validate_matrix(negative_matrix, len(negative_manifest), "negative matrix")
-    _validate_matrix(
+    _validate_embedding_artifact(
+      positive_matrix, positive_manifest, "positive matrix"
+    )
+    _validate_embedding_artifact(
+      negative_matrix, negative_manifest, "negative matrix"
+    )
+    _validate_embedding_artifact(
       issue_negative_matrix,
-      len(issue_negative_manifest),
+      issue_negative_manifest,
       "issue-negative matrix",
     )
   except ValueError as error:
@@ -1581,16 +1646,44 @@ def model_errors(
 
 
 def load_model(artifacts_dir: Path | str) -> LoadedModel:
-  np = _numpy()
   artifacts = Path(artifacts_dir)
   manifest = json.loads((artifacts / MODEL_MANIFEST).read_text(encoding="utf-8"))
-  with np.load(artifacts / CLASSIFIER_FILE, allow_pickle=False) as model:
-    coefficients = np.asarray(model["coef"], dtype=np.float64)
-    intercept = float(np.asarray(model["intercept"])[0])
-    classes = np.asarray(model["classes"])
-  if coefficients.shape != (EMBEDDING_DIMENSION,) or classes.tolist() != [0, 1]:
-    raise ValueError("Invalid paperbot classifier artifact")
-  return LoadedModel(coefficients, intercept, str(manifest["model_hash"]))
+  if not isinstance(manifest, Mapping):
+    raise ValueError("Invalid paperbot model manifest")
+  schema = manifest.get("schema")
+  if (
+    not isinstance(schema, int)
+    or isinstance(schema, bool)
+    or schema != ARTIFACT_SCHEMA
+    or not _json_contract_equal(manifest.get("embedding"), EMBEDDING_CONFIG)
+    or not _json_contract_equal(manifest.get("classifier"), CLASSIFIER_CONFIG)
+  ):
+    raise ValueError("Invalid paperbot model specification")
+  coefficients, intercept, _classes = _load_classifier_artifact(
+    artifacts / CLASSIFIER_FILE
+  )
+  has_issue_feedback = any(
+    str(field).startswith("issue_negative_") for field in manifest
+  )
+  try:
+    expected_hash = _model_hash(
+      coefficients,
+      intercept,
+      str(manifest["bibliography_hash"]),
+      str(manifest["negative_corpus_file_hash"]),
+      str(manifest["negative_metadata_file_hash"]),
+      (
+        str(manifest["issue_negative_training_hash"])
+        if has_issue_feedback
+        else None
+      ),
+    )
+  except (KeyError, UnicodeEncodeError) as error:
+    raise ValueError("Invalid paperbot model hash provenance") from error
+  model_hash = str(manifest.get("model_hash") or "")
+  if SHA256_RE.fullmatch(model_hash) is None or model_hash != expected_hash:
+    raise ValueError("Paperbot classifier does not match its model manifest")
+  return LoadedModel(coefficients, intercept, model_hash)
 
 
 def score_embeddings(embeddings: Any, model: LoadedModel) -> Any:
@@ -1622,8 +1715,95 @@ def _validate_matrix(matrix: Any, rows: int, label: str) -> None:
   if getattr(matrix, "shape", None) != (rows, EMBEDDING_DIMENSION):
     raise ValueError(f"{label} has shape {getattr(matrix, 'shape', None)}, expected {(rows, EMBEDDING_DIMENSION)}")
   np = _numpy()
-  if not np.isfinite(matrix).all():
+  try:
+    finite = bool(np.isfinite(matrix).all())
+  except TypeError as error:
+    raise ValueError(f"{label} has a non-numeric dtype") from error
+  if not finite:
     raise ValueError(f"{label} contains non-finite values")
+
+
+def _validate_embedding_vectors(matrix: Any, rows: int, label: str) -> None:
+  """Validate the numerical contract promised by the SPECTER2 artifacts."""
+
+  np = _numpy()
+  _validate_matrix(matrix, rows, label)
+  if np.asarray(matrix).dtype != np.dtype(np.float32):
+    raise ValueError(f"{label} has dtype {np.asarray(matrix).dtype}, expected float32")
+  if rows:
+    norms = np.linalg.norm(np.asarray(matrix, dtype=np.float64), axis=1)
+    if not np.allclose(norms, 1.0, rtol=1e-5, atol=1e-5):
+      raise ValueError(f"{label} contains vectors that are not L2-normalized")
+
+
+def _validate_embedding_artifact(
+  matrix: Any,
+  manifest: Sequence[Mapping[str, Any]],
+  label: str,
+) -> None:
+  """Validate matrix bytes and their canonical one-to-one row mapping."""
+
+  _validate_embedding_vectors(matrix, len(manifest), label)
+  identifiers: set[str] = set()
+  for index, row in enumerate(manifest):
+    row_index = row.get("row")
+    if (
+      not isinstance(row_index, int)
+      or isinstance(row_index, bool)
+      or row_index != index
+    ):
+      raise ValueError(
+        f"{label} manifest row {index} has noncanonical index {row_index!r}"
+      )
+    active = row.get("active")
+    if active is not True and active is not False:
+      raise ValueError(f"{label} manifest row {index} has an invalid active flag")
+    identifier = str(row.get("work_id") or row.get("paper_id") or "").strip()
+    if not identifier:
+      raise ValueError(f"{label} manifest row {index} has no identifier")
+    normalized_identifier = identifier.casefold()
+    if normalized_identifier in identifiers:
+      raise ValueError(f"{label} manifest contains duplicate identifier {identifier}")
+    identifiers.add(normalized_identifier)
+    for hash_field in ("abstract_hash", "input_hash"):
+      value = str(row.get(hash_field) or "")
+      if SHA256_RE.fullmatch(value) is None:
+        raise ValueError(
+          f"{label} manifest row {index} has an invalid {hash_field}"
+        )
+
+
+def _load_classifier_artifact(path: Path) -> tuple[Any, float, Any]:
+  """Load the non-pickle classifier while rejecting ambiguous array layouts."""
+
+  np = _numpy()
+  with np.load(path, allow_pickle=False) as model:
+    if set(model.files) != {"coef", "intercept", "classes"}:
+      raise ValueError("classifier archive has unexpected or missing arrays")
+    coefficients = np.asarray(model["coef"])
+    intercept_array = np.asarray(model["intercept"])
+    classes = np.asarray(model["classes"])
+  if coefficients.dtype != np.dtype(np.float64):
+    raise ValueError(
+      f"classifier coefficients have dtype {coefficients.dtype}, expected float64"
+    )
+  if intercept_array.dtype != np.dtype(np.float64):
+    raise ValueError(
+      f"classifier intercept has dtype {intercept_array.dtype}, expected float64"
+    )
+  if classes.dtype != np.dtype(np.int64):
+    raise ValueError(
+      f"classifier classes have dtype {classes.dtype}, expected int64"
+    )
+  if coefficients.shape != (EMBEDDING_DIMENSION,):
+    raise ValueError(f"classifier coefficients have shape {coefficients.shape}")
+  if intercept_array.shape != (1,):
+    raise ValueError(f"classifier intercept has shape {intercept_array.shape}")
+  if classes.shape != (2,) or classes.tolist() != [0, 1]:
+    raise ValueError(f"classifier classes are {classes.tolist()}, expected [0, 1]")
+  if not np.isfinite(coefficients).all() or not np.isfinite(intercept_array).all():
+    raise ValueError("classifier contains non-finite values")
+  return coefficients, float(intercept_array[0]), classes
 
 
 def _dependency_versions() -> dict[str, str]:
@@ -1693,8 +1873,12 @@ def _verify_reusable_embedding_artifacts(
     for kind in ("matrix", "manifest")
   )
   if (
-    old_model_manifest.get("schema") != ARTIFACT_SCHEMA
-    or old_model_manifest.get("embedding") != EMBEDDING_CONFIG
+    not isinstance(old_model_manifest.get("schema"), int)
+    or isinstance(old_model_manifest.get("schema"), bool)
+    or old_model_manifest.get("schema") != ARTIFACT_SCHEMA
+    or not _json_contract_equal(
+      old_model_manifest.get("embedding"), EMBEDDING_CONFIG
+    )
     or any(
       not isinstance(old_model_manifest.get(name), str)
       or SHA256_RE.fullmatch(str(old_model_manifest.get(name))) is None
@@ -1713,10 +1897,15 @@ def _verify_reusable_embedding_artifacts(
     expected_matrix_hash = str(old_model_manifest[f"{label}_matrix_hash"])
     expected_manifest_hash = str(old_model_manifest[f"{label}_manifest_hash"])
     try:
-      matrix_hash = _array_hash(_load_npy(matrix_path))
-      manifest_hash = _records_hash(_read_jsonl(rows_path))
+      matrix = _load_npy(matrix_path)
+      rows = _read_jsonl(rows_path)
+      _validate_embedding_artifact(matrix, rows, f"{label} matrix")
+      matrix_hash = _array_hash(matrix)
+      manifest_hash = _records_hash(rows)
     except Exception as error:
-      raise ValueError(f"Cannot safely reuse {label} embedding artifacts: {error}") from error
+      raise ValueError(
+        f"Refusing to reuse corrupt {label} embedding artifacts: {error}"
+      ) from error
     if matrix_hash != expected_matrix_hash or manifest_hash != expected_manifest_hash:
       raise ValueError(
         f"Refusing to reuse corrupt {label} embedding artifacts; restore or rebuild them explicitly"
@@ -1735,8 +1924,12 @@ def _verify_reusable_issue_embedding_artifacts(
   expected_matrix_hash = old_model_manifest.get("issue_negative_matrix_hash")
   expected_manifest_hash = old_model_manifest.get("issue_negative_manifest_hash")
   if (
-    old_model_manifest.get("schema") != ARTIFACT_SCHEMA
-    or old_model_manifest.get("embedding") != EMBEDDING_CONFIG
+    not isinstance(old_model_manifest.get("schema"), int)
+    or isinstance(old_model_manifest.get("schema"), bool)
+    or old_model_manifest.get("schema") != ARTIFACT_SCHEMA
+    or not _json_contract_equal(
+      old_model_manifest.get("embedding"), EMBEDDING_CONFIG
+    )
     or not isinstance(expected_matrix_hash, str)
     or SHA256_RE.fullmatch(expected_matrix_hash) is None
     or not isinstance(expected_manifest_hash, str)
@@ -1746,11 +1939,14 @@ def _verify_reusable_issue_embedding_artifacts(
   ):
     return False
   try:
-    matrix_hash = _array_hash(_load_npy(matrix_path))
-    manifest_hash = _records_hash(_read_jsonl(manifest_path))
+    matrix = _load_npy(matrix_path)
+    rows = _read_jsonl(manifest_path)
+    _validate_embedding_artifact(matrix, rows, "issue-negative matrix")
+    matrix_hash = _array_hash(matrix)
+    manifest_hash = _records_hash(rows)
   except Exception as error:
     raise ValueError(
-      f"Cannot safely reuse issue-negative embedding artifacts: {error}"
+      f"Refusing to reuse corrupt issue-negative embedding artifacts: {error}"
     ) from error
   if (
     matrix_hash != expected_matrix_hash

--- a/scripts/paperbot/pr_safety.py
+++ b/scripts/paperbot/pr_safety.py
@@ -66,6 +66,7 @@ def is_sensitive_path(value: str) -> bool:
     or path == ".gitattributes"
     or path.endswith("/.gitattributes")
     or path == ".lfsconfig"
+    or path == ".github/CODEOWNERS"
     or path in {"paperbot.toml", "requirements-paperbot.lock"}
     or path.startswith(".github/workflows/")
     or path.startswith("paper_relevance/pubmed_negatives_v1")

--- a/scripts/paperbot/pr_safety.py
+++ b/scripts/paperbot/pr_safety.py
@@ -61,6 +61,11 @@ def is_sensitive_path(value: str) -> bool:
     return True
   return (
     path.startswith("scripts/paperbot/")
+    # Git attributes and LFS configuration can transform or redirect the
+    # generated files when the privileged commit step stages them.
+    or path == ".gitattributes"
+    or path.endswith("/.gitattributes")
+    or path == ".lfsconfig"
     or path in {"paperbot.toml", "requirements-paperbot.lock"}
     or path.startswith(".github/workflows/")
     or path.startswith("paper_relevance/pubmed_negatives_v1")
@@ -73,10 +78,14 @@ def is_sensitive_path(value: str) -> bool:
 def classify_paths(
   paths: Iterable[str], *, event_name: str, same_repository: bool
 ) -> SafetyDecision:
-  sensitive = any(is_sensitive_path(path) for path in paths)
+  normalized_paths = tuple(normalize_repo_path(path) for path in paths)
+  sensitive = any(is_sensitive_path(path) for path in normalized_paths)
   return SafetyDecision(
     auto_refresh=(
-      event_name == "pull_request" and same_repository and not sensitive
+      event_name == "pull_request"
+      and same_repository
+      and "bibliography.bib" in normalized_paths
+      and not sensitive
     ),
     sensitive_change=sensitive,
   )

--- a/scripts/paperbot/pr_safety.py
+++ b/scripts/paperbot/pr_safety.py
@@ -19,6 +19,9 @@ GENERATED_PATHS = frozenset(
     "paper_relevance/positive_manifest.jsonl",
     "paper_relevance/negative_embeddings.npy",
     "paper_relevance/negative_manifest.jsonl",
+    "paper_relevance/issue_negatives.jsonl",
+    "paper_relevance/issue_negative_embeddings.npy",
+    "paper_relevance/issue_negative_manifest.jsonl",
     "paper_relevance/classifier.npz",
     "paper_relevance/model_manifest.json",
   }

--- a/scripts/paperbot/records.py
+++ b/scripts/paperbot/records.py
@@ -396,7 +396,21 @@ def _timestamp_value(value: datetime | None) -> float:
   return value.timestamp() if value else float("-inf")
 
 
-def _latest_key(record: PaperRecord) -> tuple[float, int, int, int, int, str]:
+def _stable_record_key(record: PaperRecord) -> str:
+  """Return a complete deterministic tie-break for provider-equivalent rows."""
+
+  return json.dumps(
+    record.to_dict(),
+    ensure_ascii=False,
+    sort_keys=True,
+    separators=(",", ":"),
+    default=str,
+  )
+
+
+def _latest_key(
+  record: PaperRecord,
+) -> tuple[float, int, int, int, int, str, str]:
   return (
     _timestamp_value(record.updated_at or record.created_at),
     int(record.metadata.get("record_kind") == "publication-relation"),
@@ -404,6 +418,7 @@ def _latest_key(record: PaperRecord) -> tuple[float, int, int, int, int, str]:
     int(bool(record.abstract)),
     len(record.abstract),
     record.canonical_id,
+    _stable_record_key(record),
   )
 
 
@@ -587,8 +602,16 @@ def _merge_group(records: Sequence[PaperRecord]) -> PaperRecord:
   doi = _preferred_doi(records)
   pmid = min((record.pmid for record in records if record.pmid), default="")
   arxiv_id = min((record.arxiv_id for record in records if record.arxiv_id), default="")
-  abstract = latest.abstract or max((record.abstract for record in records), key=len, default="")
-  authors = latest.authors or max((record.authors for record in records), key=len, default=())
+  abstract_record = max(
+    records,
+    key=lambda record: (len(record.abstract), _latest_key(record)),
+  )
+  author_record = max(
+    records,
+    key=lambda record: (len(record.authors), _latest_key(record)),
+  )
+  abstract = latest.abstract or abstract_record.abstract
+  authors = latest.authors or author_record.authors
   categories = tuple(sorted({item for record in records for item in record.categories}))
   related = {item for record in records for item in record.related_ids}
   for record in records:
@@ -607,6 +630,21 @@ def _merge_group(records: Sequence[PaperRecord]) -> PaperRecord:
     if record.metadata.get("record_kind") == "publication-relation"
   ]
   publication = max(publication_records, key=_latest_key) if publication_records else None
+  venue_record = max(
+    (record for record in records if record.venue),
+    key=_latest_key,
+    default=None,
+  )
+  license_record = max(
+    (record for record in records if record.license),
+    key=_latest_key,
+    default=None,
+  )
+  url_record = max(
+    (record for record in records if record.url),
+    key=_latest_key,
+    default=None,
+  )
   if publication and publication.metadata.get("publication_year"):
     metadata["publication_year"] = publication.metadata["publication_year"]
   if len(records) > 1:
@@ -616,7 +654,7 @@ def _merge_group(records: Sequence[PaperRecord]) -> PaperRecord:
     abstract=abstract,
     authors=authors,
     venue=(publication.venue if publication and publication.venue else latest.venue)
-    or next((record.venue for record in records if record.venue), ""),
+    or (venue_record.venue if venue_record else ""),
     created_at=created,
     updated_at=updated,
     doi=doi,
@@ -624,8 +662,9 @@ def _merge_group(records: Sequence[PaperRecord]) -> PaperRecord:
     arxiv_id=arxiv_id,
     categories=categories,
     related_ids=tuple(sorted(related)),
-    license=latest.license or next((record.license for record in records if record.license), ""),
-    url=publication.url if publication and publication.url else latest.url,
+    license=latest.license or (license_record.license if license_record else ""),
+    url=(publication.url if publication and publication.url else latest.url)
+    or (url_record.url if url_record else ""),
     metadata=metadata,
   )
 

--- a/scripts/paperbot/records.py
+++ b/scripts/paperbot/records.py
@@ -520,6 +520,7 @@ def _union_preprint_publication_matches(
       if key := _title_author_key(record):
         buckets.setdefault(key, set()).add(root)
 
+  candidate_edges: set[tuple[int, int]] = set()
   for roots in buckets.values():
     if len(roots) != 2:
       continue
@@ -545,7 +546,7 @@ def _union_preprint_publication_matches(
     if cross_stage and _year_sets_within(
       left["years"], right["years"], PREPRINT_PUBLICATION_YEAR_GAP
     ):
-      groups.union(left_root, right_root)
+      candidate_edges.add((left_root, right_root))
       continue
 
     # PubMed occasionally lacks a DOI while a provider's publication record
@@ -566,6 +567,16 @@ def _union_preprint_publication_matches(
       and not left_preprint
     )
     if doi_pmid_complement and _year_sets_within(left["years"], right["years"], 1):
+      candidate_edges.add((left_root, right_root))
+
+  neighbors: dict[int, set[int]] = {}
+  for left_root, right_root in candidate_edges:
+    neighbors.setdefault(left_root, set()).add(right_root)
+    neighbors.setdefault(right_root, set()).add(left_root)
+  for left_root, right_root in sorted(candidate_edges):
+    # A component may retain several historical titles. Refuse to let bucket
+    # iteration order select one of multiple plausible cross-stage matches.
+    if len(neighbors[left_root]) == 1 and len(neighbors[right_root]) == 1:
       groups.union(left_root, right_root)
 
 

--- a/tests/paperbot/test_backfill.py
+++ b/tests/paperbot/test_backfill.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -24,6 +26,21 @@ class _Resolver:
 class _FailingResolver:
   def resolve(self, _fields: dict[str, str]) -> ResolvedAbstract:
     raise AssertionError("a title-only exception must not trigger a provider lookup")
+
+
+class _IdentityResolver:
+  def __init__(self, text: str = "") -> None:
+    self.calls = 0
+    self.text = text
+
+  def resolve(self, fields: dict[str, str]) -> ResolvedAbstract:
+    self.calls += 1
+    return ResolvedAbstract(
+      self.text or f"Abstract resolved for {fields.get('doi', 'unknown')}.",
+      "fixture",
+      "",
+      "unknown",
+    )
 
 
 class BackfillTests(unittest.TestCase):
@@ -121,6 +138,371 @@ class BackfillTests(unittest.TestCase):
         provenance["license"],
         "https://creativecommons.org/licenses/by/4.0/",
       )
+
+  def test_backfill_rejects_duplicate_citation_keys_before_lookup(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      original = """@article{same,
+  title = {First paper},
+  author = {First, Ada},
+  year = {2024},
+  doi = {10.1000/first},
+}
+
+@article{SAME,
+  title = {Second paper},
+  author = {Second, Ada},
+  year = {2024},
+  doi = {10.1000/second},
+}
+"""
+      bibliography.write_text(original, encoding="utf-8")
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      resolver = _IdentityResolver()
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      with self.assertRaisesRegex(ValueError, "Duplicate BibTeX citation keys"):
+        backfill_bibliography(config, resolver=resolver)
+
+      self.assertEqual(resolver.calls, 0)
+      self.assertEqual(bibliography.read_text(encoding="utf-8"), original)
+
+  def test_backfill_preserves_comments_directives_and_value_expressions(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      original = """% Keep this comment, including a fake @article{ignored} marker.
+@string{venueName = "Journal of Examples"}
+@preamble("Bibliography generated for " # venueName)
+
+@article(macro2024,
+  title = "A molecular " # "paper",
+  author = {Macro, Ada},
+  year = 2024,
+  journal = venueName,
+  note = {An unmatched parenthesis ) remains part of this field},
+  doi = {10.1000/macro},
+)
+
+@article{existing2023,
+  title = {An existing paper},
+  author = {Existing, Ada},
+  year = {2023},
+  abstract = {Already complete.},
+}
+"""
+      bibliography.write_text(original, encoding="utf-8")
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      fetched = "A 50% result with unmatched {{ left and one } right brace."
+      result = backfill_bibliography(
+        config,
+        resolver=_IdentityResolver(fetched),
+      )
+      updated = bibliography.read_text(encoding="utf-8")
+
+      self.assertTrue(result.changed)
+      self.assertIn(
+        "% Keep this comment, including a fake @article{ignored} marker.",
+        updated,
+      )
+      self.assertIn('@string{venueName = "Journal of Examples"}', updated)
+      self.assertIn(
+        '@preamble("Bibliography generated for " # venueName)',
+        updated,
+      )
+      self.assertIn('title = "A molecular " # "paper",', updated)
+      self.assertIn("journal = venueName,", updated)
+      self.assertIn(
+        "note = {An unmatched parenthesis ) remains part of this field},",
+        updated,
+      )
+      self.assertIn(
+        r"abstract = {A 50\% result with unmatched \{\{ left and one \} right brace.},",
+        updated,
+      )
+      parsed = load_bibliography(bibliography)
+      self.assertEqual(len(parsed), 2)
+      entry = parsed[0]
+      self.assertEqual(entry.fields["title"], "A molecular paper")
+      self.assertEqual(entry.fields["doi"], "10.1000/macro")
+      self.assertEqual(entry.abstract, fetched)
+      self.assertEqual(parsed[1].abstract, "Already complete.")
+
+  def test_backfill_places_separator_before_a_trailing_comment(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      bibliography.write_text(
+        "@article{commented,\n"
+        "  title = {A commented paper},\n"
+        "  author = {Comment, Ada},\n"
+        "  year = {2024},\n"
+        "  doi = {10.1000/commented} % preserve this comment\n"
+        "}\n",
+        encoding="utf-8",
+      )
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      backfill_bibliography(
+        config,
+        resolver=_IdentityResolver("A fetched abstract."),
+      )
+      updated = bibliography.read_text(encoding="utf-8")
+
+      self.assertIn(
+        "doi = {10.1000/commented}, % preserve this comment",
+        updated,
+      )
+      [entry] = load_bibliography(bibliography)
+      self.assertEqual(entry.abstract, "A fetched abstract.")
+
+  def test_backfill_protects_backslashes_immediately_before_braces(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      bibliography.write_text(
+        "@article{slashes,\n"
+        "  title = {A slash paper},\n"
+        "  author = {Slash, Ada},\n"
+        "  year = {2024},\n"
+        "  doi = {10.1000/slashes},\n"
+        "}\n",
+        encoding="utf-8",
+      )
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+      fetched = r"Literal \\{left, \\} right, and \\% percent sequences."
+
+      backfill_bibliography(
+        config,
+        resolver=_IdentityResolver(fetched),
+      )
+      updated = bibliography.read_text(encoding="utf-8")
+
+      self.assertIn(
+        r"\textbackslash{}\textbackslash{}\{left",
+        updated,
+      )
+      [entry] = load_bibliography(bibliography)
+      self.assertEqual(entry.abstract, fetched)
+
+  def test_backfill_replaces_empty_abstract_field_without_duplication(
+    self,
+  ) -> None:
+    for empty_value in ("{}", '""', "{}, % preserve empty-field comment"):
+      with self.subTest(empty_value=empty_value):
+        with tempfile.TemporaryDirectory() as directory:
+          root = Path(directory)
+          bibliography = root / "bibliography.bib"
+          bibliography.write_text(
+            "@article{empty,\n"
+            "  title = {An empty abstract paper},\n"
+            "  author = {Empty, Ada},\n"
+            "  year = {2024},\n"
+              f"  abstract = {empty_value}"
+              f"{'' if '%' in empty_value else ','}\n"
+            "  doi = {10.1000/empty},\n"
+            "}\n",
+            encoding="utf-8",
+          )
+          artifacts = root / "artifacts"
+          artifacts.mkdir()
+          exceptions = artifacts / "exceptions.json"
+          exceptions.write_text("{}\n", encoding="utf-8")
+          config = PaperbotConfig(
+            bibliography_path=bibliography,
+            artifact_dir=artifacts,
+            abstract_exceptions_path=exceptions,
+          )
+
+          backfill_bibliography(
+            config,
+            resolver=_IdentityResolver("A replacement abstract."),
+          )
+          updated = bibliography.read_text(encoding="utf-8")
+
+          self.assertEqual(len(re.findall(r"(?i)\babstract\s*=", updated)), 1)
+          if "%" in empty_value:
+            self.assertIn("% preserve empty-field comment", updated)
+          [entry] = load_bibliography(bibliography)
+          self.assertEqual(entry.abstract, "A replacement abstract.")
+
+  def test_backfill_ignores_braces_inside_field_comments(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      bibliography.write_text(
+        "@article{comment-brace,\n"
+        "  title = {A title % } is inside the comment\n"
+        "    that continues here},\n"
+        "  author = {Comment, Ada},\n"
+        "  year = {2024},\n"
+        "  abstract = {},\n"
+        "  doi = {10.1000/comment-brace},\n"
+        "}\n",
+        encoding="utf-8",
+      )
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      result = backfill_bibliography(
+        config,
+        resolver=_IdentityResolver("A fetched abstract."),
+      )
+      updated = bibliography.read_text(encoding="utf-8")
+
+      self.assertTrue(result.changed)
+      self.assertEqual(result.unresolved, ())
+      self.assertEqual(len(re.findall(r"(?i)\babstract\s*=", updated)), 1)
+      self.assertIn("% } is inside the comment", updated)
+      [entry] = load_bibliography(bibliography)
+      self.assertEqual(entry.abstract, "A fetched abstract.")
+
+  def test_backfill_rejects_markup_that_normalizes_to_an_empty_abstract(
+    self,
+  ) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      bibliography.write_text(
+        "@article{empty-markup,\n"
+        "  title = {An unresolved paper},\n"
+        "  author = {Empty, Ada},\n"
+        "  year = {2024},\n"
+        "  doi = {10.1000/empty-markup},\n"
+        "}\n",
+        encoding="utf-8",
+      )
+      original = bibliography.read_text(encoding="utf-8")
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      result = backfill_bibliography(
+        config,
+        resolver=_IdentityResolver("<p></p>"),
+      )
+
+      self.assertFalse(result.changed)
+      self.assertEqual(result.abstracts_added, 0)
+      self.assertEqual(result.aliases_filled, 0)
+      self.assertEqual(result.unresolved, ("empty-markup",))
+      self.assertEqual(bibliography.read_text(encoding="utf-8"), original)
+
+  def test_backfill_preserves_provenance_when_canonical_id_changes(
+    self,
+  ) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+      root = Path(directory)
+      bibliography = root / "bibliography.bib"
+      abstract = "The same abstract."
+      bibliography.write_text(
+        "@misc{preprint,\n"
+        "  title = {A shared work},\n"
+        "  author = {Shared, Ada},\n"
+        "  year = {2023},\n"
+        f"  abstract = {{{abstract}}},\n"
+        "  doi = {10.21203/rs.3.rs-123/v1},\n"
+        "}\n"
+        "@article{published,\n"
+        "  title = {A shared work},\n"
+        "  author = {Shared, Ada},\n"
+        "  year = {2024},\n"
+        "  doi = {10.9999/published},\n"
+        "}\n",
+        encoding="utf-8",
+      )
+      artifacts = root / "artifacts"
+      artifacts.mkdir()
+      exceptions = artifacts / "exceptions.json"
+      exceptions.write_text("{}\n", encoding="utf-8")
+      old_retrieval = "2024-01-02T03:04:05+00:00"
+      (artifacts / "abstract_provenance.jsonl").write_text(
+        json.dumps(
+          {
+            "schema_version": 1,
+            "work_id": "doi:10.21203/rs.3.rs-123/v1",
+            "citekey": "preprint",
+            "aliases": ["preprint"],
+            "source": "crossref",
+            "source_url": "https://example.test/old",
+            "retrieved_at": old_retrieval,
+            "text_sha256": hashlib.sha256(
+              abstract.encode("utf-8")
+            ).hexdigest(),
+            "license": "source rights retained",
+          },
+          sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+      )
+      config = PaperbotConfig(
+        bibliography_path=bibliography,
+        artifact_dir=artifacts,
+        abstract_exceptions_path=exceptions,
+      )
+
+      result = backfill_bibliography(config)
+      [provenance] = [
+        json.loads(line)
+        for line in (artifacts / "abstract_provenance.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+      ]
+
+      self.assertEqual(result.unresolved, ())
+      self.assertEqual(provenance["work_id"], "doi:10.9999/published")
+      self.assertEqual(provenance["source"], "crossref")
+      self.assertEqual(
+        provenance["source_url"], "https://example.test/old"
+      )
+      self.assertEqual(provenance["retrieved_at"], old_retrieval)
 
 
 if __name__ == "__main__":

--- a/tests/paperbot/test_bibliography.py
+++ b/tests/paperbot/test_bibliography.py
@@ -76,6 +76,47 @@ class BibtexTests(unittest.TestCase):
     self.assertEqual([entry.key for entry in entries], ["quoted", "later"])
     self.assertIn('"surprising result', entries[0].abstract)
 
+  def test_malformed_entries_and_fields_fail_closed(self) -> None:
+    for source, message in (
+      ("@article{missing-separator}", "citation-key separator"),
+      ("@article{, title={Empty key}}", "empty citation key"),
+      (
+        "@article{bad key, title={Invalid key}}",
+        "invalid citation key",
+      ),
+      (
+        "@article{bad, title={Visible}, ???, abstract={Hidden}}",
+        "Malformed BibTeX field",
+      ),
+      (
+        "@article{duplicate, title={One}, title={Two}}",
+        "Duplicate BibTeX field",
+      ),
+      (
+        "@article{missing-value, title=, abstract={Hidden}}",
+        "missing value",
+      ),
+      (
+        "@article{missing-field-comma, title={Visible} abstract={Hidden}}",
+        "missing comma separator",
+      ),
+    ):
+      with self.subTest(source=source):
+        with self.assertRaisesRegex(ValueError, message):
+          parse_bibtex(source)
+
+  def test_bare_field_atom_stops_before_a_percent_comment(self) -> None:
+    [entry] = parse_bibtex(
+      "@article{commented-atom,\n"
+      "  title = {Visible},\n"
+      "  year = 2024 % keep this source comment\n"
+      "  , abstract = {Still parsed},\n"
+      "}\n"
+    )
+
+    self.assertEqual(entry.fields["year"], "2024")
+    self.assertEqual(entry.abstract, "Still parsed")
+
   def test_render_escapes_percent_without_changing_semantic_abstract(self) -> None:
     entry = BibliographyEntry(
       "article",
@@ -210,7 +251,7 @@ class BibtexTests(unittest.TestCase):
               "title": "Exact shared title",
               "author": "Smith, A and Jones, B",
               "year": "2024",
-              "doi": "10.1038/example",
+              "doi": "10.9999/example",
               "abstract": "Publication abstract.",
             },
           ),
@@ -219,6 +260,7 @@ class BibtexTests(unittest.TestCase):
           works = canonicalize_entries(ordering)
           self.assertEqual(len(works), 1)
           self.assertEqual(works[0].aliases, ("preprint", "published"))
+          self.assertEqual(works[0].work_id, "doi:10.9999/example")
 
   def test_identifierless_fallback_never_bridges_conflicting_dois(self) -> None:
     entries = [

--- a/tests/paperbot/test_bibliography.py
+++ b/tests/paperbot/test_bibliography.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import permutations
 import json
 import sys
 import tempfile
@@ -98,6 +99,57 @@ class BibtexTests(unittest.TestCase):
   def test_normalize_doi_strips_biorxiv_version(self) -> None:
     self.assertEqual(normalize_doi("https://doi.org/10.1101/2024.01.02.123456v3"), "10.1101/2024.01.02.123456")
 
+  def test_normalize_doi_strips_both_chemrxiv_version_styles(self) -> None:
+    self.assertEqual(
+      normalize_doi("https://doi.org/10.26434/chemrxiv-2026-example-v3"),
+      "10.26434/chemrxiv-2026-example",
+    )
+    self.assertEqual(
+      normalize_doi("https://doi.org/10.26434/chemrxiv.15006393/v4"),
+      "10.26434/chemrxiv.15006393",
+    )
+
+  def test_chemrxiv_versions_receive_one_positive_training_weight(self) -> None:
+    for doi_v1, doi_v2 in (
+      (
+        "10.26434/chemrxiv-2026-example-v1",
+        "10.26434/chemrxiv-2026-example-v2",
+      ),
+      (
+        "10.26434/chemrxiv.15006393/v1",
+        "10.26434/chemrxiv.15006393/v2",
+      ),
+    ):
+      with self.subTest(doi_v1=doi_v1):
+        entries = [
+          BibliographyEntry(
+            "misc",
+            "version-one",
+            {
+              "title": "ChemRxiv work",
+              "author": "Smith, A",
+              "year": "2025",
+              "doi": doi_v1,
+              "abstract": "First version.",
+            },
+          ),
+          BibliographyEntry(
+            "misc",
+            "version-two",
+            {
+              "title": "ChemRxiv work revised",
+              "author": "Smith, A",
+              "year": "2026",
+              "doi": doi_v2,
+              "abstract": "Second version.",
+            },
+          ),
+        ]
+        for ordering in permutations(entries):
+          works = canonicalize_entries(ordering)
+          self.assertEqual(len(works), 1)
+          self.assertEqual(works[0].aliases, ("version-one", "version-two"))
+
   def test_canonicalize_merges_shared_identifier_once(self) -> None:
     works = canonicalize_entries(parse_bibtex(SAMPLE))
     self.assertEqual(len(works), 1)
@@ -129,6 +181,246 @@ class BibtexTests(unittest.TestCase):
     works = canonicalize_entries(entries)
     self.assertEqual(len(works), 1)
     self.assertEqual(works[0].work_id, "doi:10.1038/example")
+
+  def test_all_supported_preprint_doi_families_bridge_to_publications(self) -> None:
+    for preprint_doi in (
+      "10.1101/2022.01.01.123456",
+      "10.21203/rs.3.rs-123/v1",
+      "10.26434/chemrxiv-2022-example-v1",
+      "10.48550/arxiv.2201.00001",
+      "10.64898/2022.01.01.123456",
+    ):
+      with self.subTest(preprint_doi=preprint_doi):
+        entries = [
+          BibliographyEntry(
+            "misc",
+            "preprint",
+            {
+              "title": "Exact shared title",
+              "author": "Smith, A",
+              "year": "2022",
+              "doi": preprint_doi,
+              "abstract": "Preprint abstract.",
+            },
+          ),
+          BibliographyEntry(
+            "article",
+            "published",
+            {
+              "title": "Exact shared title",
+              "author": "Smith, A and Jones, B",
+              "year": "2024",
+              "doi": "10.1038/example",
+              "abstract": "Publication abstract.",
+            },
+          ),
+        ]
+        for ordering in permutations(entries):
+          works = canonicalize_entries(ordering)
+          self.assertEqual(len(works), 1)
+          self.assertEqual(works[0].aliases, ("preprint", "published"))
+
+  def test_identifierless_fallback_never_bridges_conflicting_dois(self) -> None:
+    entries = [
+      BibliographyEntry(
+        "article",
+        "identifierless",
+        {
+          "title": "Ambiguous shared title",
+          "author": "Smith, A",
+          "year": "2024",
+          "abstract": "No stable identifier.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "doi-a",
+        {
+          "title": "Ambiguous shared title",
+          "author": "Smith, A",
+          "year": "2024",
+          "doi": "10.1000/a",
+          "abstract": "First identified work.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "doi-b",
+        {
+          "title": "Ambiguous shared title",
+          "author": "Smith, A",
+          "year": "2024",
+          "doi": "10.1000/b",
+          "abstract": "Second identified work.",
+        },
+      ),
+    ]
+    expected = {
+      (("doi-a",), ("doi:10.1000/a",)),
+      (("doi-b",), ("doi:10.1000/b",)),
+      (("identifierless",), ()),
+    }
+
+    for ordering in permutations(entries):
+      with self.subTest(ordering=tuple(entry.key for entry in ordering)):
+        works = canonicalize_entries(ordering)
+        actual = {(work.aliases, work.identifiers) for work in works}
+        self.assertEqual(actual, expected)
+
+  def test_ambiguous_preprint_publication_fallback_is_order_independent(self) -> None:
+    entries = [
+      BibliographyEntry(
+        "misc",
+        "preprint",
+        {
+          "title": "Ambiguous publication title",
+          "author": "Smith, A",
+          "year": "2022",
+          "doi": "10.1101/2022.01.01.123456",
+          "abstract": "Preprint abstract.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "journal-a",
+        {
+          "title": "Ambiguous publication title",
+          "author": "Smith, A",
+          "year": "2023",
+          "doi": "10.1000/a",
+          "abstract": "First publication.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "journal-b",
+        {
+          "title": "Ambiguous publication title",
+          "author": "Smith, A",
+          "year": "2024",
+          "doi": "10.1000/b",
+          "abstract": "Second publication.",
+        },
+      ),
+    ]
+    expected_aliases = {
+      ("journal-a",),
+      ("journal-b",),
+      ("preprint",),
+    }
+
+    for ordering in permutations(entries):
+      with self.subTest(ordering=tuple(entry.key for entry in ordering)):
+        works = canonicalize_entries(ordering)
+        self.assertEqual({work.aliases for work in works}, expected_aliases)
+        self.assertEqual(len(works), 3)
+
+  def test_mixed_identity_component_does_not_absorb_another_publication(self) -> None:
+    entries = [
+      BibliographyEntry(
+        "misc",
+        "preprint-title",
+        {
+          "title": "Shared target title",
+          "author": "Smith, A",
+          "year": "2022",
+          "doi": "10.1101/2022.01.01.123456",
+          "abstract": "Preprint abstract.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "explicitly-linked",
+        {
+          "title": "Earlier title",
+          "author": "Smith, A",
+          "year": "2023",
+          "doi": "10.1000/a",
+          "preprint_doi": "10.1101/2022.01.01.123456",
+          "abstract": "The explicitly linked publication.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "other-publication",
+        {
+          "title": "Shared target title",
+          "author": "Smith, A",
+          "year": "2024",
+          "doi": "10.1000/b",
+          "abstract": "A distinct publication with ambiguous metadata.",
+        },
+      ),
+    ]
+    expected_aliases = {
+      ("explicitly-linked", "preprint-title"),
+      ("other-publication",),
+    }
+
+    for ordering in permutations(entries):
+      with self.subTest(ordering=tuple(entry.key for entry in ordering)):
+        works = canonicalize_entries(ordering)
+        self.assertEqual({work.aliases for work in works}, expected_aliases)
+
+  def test_revised_preprint_titles_do_not_choose_a_publication_by_order(
+    self,
+  ) -> None:
+    entries = [
+      BibliographyEntry(
+        "misc",
+        "preprint-old-title",
+        {
+          "title": "Original preprint title",
+          "author": "Smith, A",
+          "year": "2022",
+          "doi": "10.1101/2022.01.01.123456",
+          "abstract": "Original preprint abstract.",
+        },
+      ),
+      BibliographyEntry(
+        "misc",
+        "preprint-new-title",
+        {
+          "title": "Revised preprint title",
+          "author": "Smith, A",
+          "year": "2022",
+          "doi": "10.1101/2022.01.01.123456",
+          "abstract": "Revised preprint abstract.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "publication-for-old-title",
+        {
+          "title": "Original preprint title",
+          "author": "Smith, A",
+          "year": "2023",
+          "doi": "10.1000/old-title",
+          "abstract": "First plausible publication.",
+        },
+      ),
+      BibliographyEntry(
+        "article",
+        "publication-for-new-title",
+        {
+          "title": "Revised preprint title",
+          "author": "Smith, A",
+          "year": "2024",
+          "doi": "10.1000/new-title",
+          "abstract": "Second plausible publication.",
+        },
+      ),
+    ]
+    expected_aliases = {
+      ("preprint-new-title", "preprint-old-title"),
+      ("publication-for-new-title",),
+      ("publication-for-old-title",),
+    }
+
+    for ordering in permutations(entries):
+      with self.subTest(ordering=tuple(entry.key for entry in ordering)):
+        works = canonicalize_entries(ordering)
+        self.assertEqual({work.aliases for work in works}, expected_aliases)
 
   def test_abstract_exceptions_are_reasoned_and_affect_hash(self) -> None:
     work = canonicalize_entries([

--- a/tests/paperbot/test_cli.py
+++ b/tests/paperbot/test_cli.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from scripts.paperbot.cli import build_parser, main
+
+
+def test_sync_issue_negatives_command_is_registered() -> None:
+  args = build_parser().parse_args(["sync-issue-negatives"])
+
+  assert args.command == "sync-issue-negatives"
+
+
+def test_sync_issue_negatives_passes_the_builtin_token(
+  monkeypatch: pytest.MonkeyPatch,
+  capsys: pytest.CaptureFixture[str],
+) -> None:
+  calls: list[tuple[Any, str]] = []
+  collector = ModuleType("scripts.paperbot.issue_negatives")
+
+  def sync_issue_negatives(config: Any, *, github_token: str) -> dict[str, Any]:
+    calls.append((config, github_token))
+    return {"active_count": 3, "ok": True}
+
+  collector.sync_issue_negatives = sync_issue_negatives  # type: ignore[attr-defined]
+  monkeypatch.setitem(sys.modules, collector.__name__, collector)
+  monkeypatch.setenv("GITHUB_TOKEN", "read-only-token")
+
+  assert main(["--repo-root", str(Path.cwd()), "sync-issue-negatives"]) == 0
+  assert len(calls) == 1
+  assert calls[0][0].repository == "delalamo/SKM"
+  assert calls[0][1] == "read-only-token"
+  assert json.loads(capsys.readouterr().out) == {"active_count": 3, "ok": True}
+
+
+def test_sync_issue_negatives_requires_a_token(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+  with pytest.raises(SystemExit) as caught:
+    main(["--repo-root", str(Path.cwd()), "sync-issue-negatives"])
+
+  assert caught.value.code == 2

--- a/tests/paperbot/test_cli.py
+++ b/tests/paperbot/test_cli.py
@@ -48,3 +48,11 @@ def test_sync_issue_negatives_requires_a_token(
     main(["--repo-root", str(Path.cwd()), "sync-issue-negatives"])
 
   assert caught.value.code == 2
+
+
+def test_repo_root_requires_its_own_config(
+  tmp_path: Path,
+  capsys: pytest.CaptureFixture[str],
+) -> None:
+  assert main(["--repo-root", str(tmp_path), "check-model"]) == 1
+  assert "regular, non-symlink file" in capsys.readouterr().err

--- a/tests/paperbot/test_config.py
+++ b/tests/paperbot/test_config.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.paperbot.config import load_config
+
+
+def _write_config(root: Path, paths: str = "") -> Path:
+  config = root / "paperbot.toml"
+  path_lines = paths or 'bibliography = "bibliography.bib"'
+  config.write_text(
+    'repository = "delalamo/SKM"\n'
+    "[paths]\n"
+    f"{path_lines}\n",
+    encoding="utf-8",
+  )
+  return config
+
+
+def test_confined_config_resolves_data_inside_repository(tmp_path: Path) -> None:
+  config_path = _write_config(
+    tmp_path,
+    'bibliography = "data/library.bib"\n'
+    'artifacts = "generated/model"\n'
+    'abstract_exceptions = "generated/exceptions.json"',
+  )
+
+  config = load_config(config_path, repository_root=tmp_path)
+
+  assert config.bibliography_path == tmp_path / "data/library.bib"
+  assert config.artifact_dir == tmp_path / "generated/model"
+  assert config.abstract_exceptions_path == tmp_path / "generated/exceptions.json"
+
+
+def test_confined_config_must_exist_as_a_regular_file(tmp_path: Path) -> None:
+  with pytest.raises(ValueError, match="regular, non-symlink"):
+    load_config(tmp_path / "paperbot.toml", repository_root=tmp_path)
+
+  target = _write_config(tmp_path)
+  link = tmp_path / "linked.toml"
+  link.symlink_to(target)
+  with pytest.raises(ValueError, match="regular, non-symlink"):
+    load_config(link, repository_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+  "path_value",
+  [
+    "../outside.bib",
+    "/tmp/outside.bib",
+  ],
+)
+def test_confined_config_rejects_data_path_escape(
+  tmp_path: Path,
+  path_value: str,
+) -> None:
+  config_path = _write_config(
+    tmp_path,
+    f'bibliography = "{path_value}"',
+  )
+
+  with pytest.raises(ValueError, match="escapes repository root"):
+    load_config(config_path, repository_root=tmp_path)
+
+
+def test_confined_config_itself_must_be_inside_repository(tmp_path: Path) -> None:
+  repository = tmp_path / "repository"
+  repository.mkdir()
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  config_path = _write_config(outside)
+
+  with pytest.raises(ValueError, match="config must be inside"):
+    load_config(config_path, repository_root=repository)
+
+
+def test_confined_config_rejects_symlinked_data_parent(
+  tmp_path: Path,
+) -> None:
+  repository = tmp_path / "repository"
+  repository.mkdir()
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  (repository / "linked").symlink_to(outside, target_is_directory=True)
+  config_path = _write_config(
+    repository,
+    'bibliography = "linked/bibliography.bib"',
+  )
+
+  with pytest.raises(ValueError, match="escapes repository root"):
+    load_config(config_path, repository_root=repository)

--- a/tests/paperbot/test_github.py
+++ b/tests/paperbot/test_github.py
@@ -231,6 +231,25 @@ def test_identity_normalizes_doi_and_arxiv_revision() -> None:
     assert any(alias.startswith("title:") for alias in aliases)
 
 
+def test_explicit_canonical_identity_is_always_a_hashed_alias() -> None:
+    work_id, aliases = identity_for_record(
+        {
+            "canonical_id": "provider:Canonical-123",
+            "source": "other-provider",
+            "source_id": "source-456",
+            "title": "A paper",
+        }
+    )
+
+    assert work_id == "provider:canonical-123"
+    assert work_id in aliases
+
+
+def test_managed_metadata_rejects_boolean_schema_alias() -> None:
+    with pytest.raises(GitHubError, match="unsupported metadata schema"):
+        parse_managed_meta('<!-- paperbot:meta {"schema":true} -->')
+
+
 def test_identity_and_metadata_are_compatible_with_canonical_paper_record() -> None:
     record = PaperRecord(
         source="bioRxiv",
@@ -411,6 +430,8 @@ def test_load_managed_issues_paginates_and_ignores_unmanaged_and_prs() -> None:
 
     assert [issue.number for issue in index.issues] == [4]
     assert len(transport.calls) == 2
+    assert all("sort=created" in url for url in transport.calls)
+    assert all("direction=asc" in url for url in transport.calls)
 
 
 def test_read_only_client_can_use_public_github_without_a_token() -> None:
@@ -442,6 +463,24 @@ def test_alias_collision_between_issues_fails_closed() -> None:
 
     with pytest.raises(GitHubError, match="belongs to both"):
         load_managed_issues(client)
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        lambda body: body + "\n<!-- paperbot:meta {not-json} -->",
+        lambda body: body + "\n" + body,
+        lambda body: body.replace("<!-- paperbot:managed:end -->", ""),
+    ],
+)
+def test_bot_authored_malformed_managed_body_fails_before_deduplication(
+    corrupt: Any,
+) -> None:
+    issue = paper_issue(Paper())
+    issue["body"] = corrupt(issue["body"])
+
+    with pytest.raises(GitHubError, match="metadata marker|complete paperbot block"):
+        load_managed_issues(MemoryIssueClient([issue]))
 
 
 def test_user_authored_marker_cannot_claim_aliases_or_be_mutated() -> None:

--- a/tests/paperbot/test_issue_negatives.py
+++ b/tests/paperbot/test_issue_negatives.py
@@ -65,6 +65,7 @@ def managed_issue(
   login: str = "github-actions[bot]",
   prefix: str = "",
   suffix: str = "",
+  known_bib_key: str | None = None,
 ) -> dict[str, Any]:
   bibtex = (
     "@article{lovelace2026,\n"
@@ -73,10 +74,20 @@ def managed_issue(
     "}"
   )
   meta = build_managed_meta(
-    paper, 0.9, bibtex, "lovelace2026", model_hash="model"
+    paper,
+    0.9,
+    bibtex,
+    "lovelace2026",
+    model_hash="model",
+    known_bib_key=known_bib_key,
   )
   body = render_managed_body(
-    paper, 0.9, bibtex, "lovelace2026", meta=meta
+    paper,
+    0.9,
+    bibtex,
+    "lovelace2026",
+    known_bib_key=known_bib_key,
+    meta=meta,
   )
   return {
     "number": number,
@@ -550,6 +561,106 @@ def test_exact_title_match_is_conservatively_omitted_from_bibliography(
   assert row.bibliography_keys == ("positive2026",)
 
 
+def test_known_bibliography_alias_survives_metadata_drift_and_is_omitted(
+  tmp_path: Path,
+) -> None:
+  paper = record(
+    doi="10.9999/drifted",
+    pmid="",
+    source_id="drifted",
+    title="A completely drifted title",
+    abstract="Neither current text nor identifiers match the bibliography.",
+    authors=("Different Author",),
+    updated_at="2025-06-01",
+  )
+  configuration = config(tmp_path)
+  configuration.bibliography_path.write_text(
+    "@article{positive2026,\n"
+    "  title = {A useful paper},\n"
+    "  author = {Hopper, Grace},\n"
+    "  year = {2026},\n"
+    "  abstract = {A useful abstract about the target field.},\n"
+    "  doi = {10.1000/positive},\n"
+    "}\n\n"
+    "@article{positiveAlias2026,\n"
+    "  title = {A useful paper},\n"
+    "  author = {Hopper, Grace},\n"
+    "  year = {2026},\n"
+    "  abstract = {A useful abstract about the target field.},\n"
+    "  doi = {10.1000/positive},\n"
+    "}\n",
+    encoding="utf-8",
+  )
+
+  result = sync_issue_negatives(
+    configuration,
+    client=MemoryClient([
+      managed_issue(paper, known_bib_key="positiveAlias2026")
+    ]),
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert row.known_bib_keys == ("positiveAlias2026",)
+  assert row.bibliography_keys == ("positiveAlias2026",)
+  assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
+
+
+def test_nonrepresentative_bibliography_alias_title_is_omitted(
+  tmp_path: Path,
+) -> None:
+  paper = record(
+    doi="10.7777/unrelated",
+    pmid="",
+    source_id="unrelated",
+    title="Older preprint title",
+    abstract="A revised issue abstract.",
+    authors=("Different Author",),
+  )
+  configuration = config(tmp_path)
+  configuration.bibliography_path.write_text(
+    "@misc{preprint,\n"
+    "  title = {Older preprint title},\n"
+    "  author = {Hopper, Grace},\n"
+    "  year = {2024},\n"
+    "  abstract = {The original preprint abstract.},\n"
+    "  doi = {10.21203/rs.3.rs-123/v1},\n"
+    "  relateddoi = {10.9999/published},\n"
+    "}\n"
+    "@article{published,\n"
+    "  title = {New publication title},\n"
+    "  author = {Hopper, Grace},\n"
+    "  year = {2026},\n"
+    "  abstract = {The final publication abstract is longer.},\n"
+    "  doi = {10.9999/published},\n"
+    "}\n",
+    encoding="utf-8",
+  )
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
+  assert row.bibliography_keys
+
+
+@pytest.mark.parametrize("known_bib_key", ["", " positive2026 "])
+def test_known_bibliography_key_must_be_canonical_nonempty_text(
+  tmp_path: Path, known_bib_key: str
+) -> None:
+  issue = managed_issue(record(), known_bib_key=known_bib_key)
+
+  with pytest.raises(GitHubError, match="invalid known bibliography key"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
 def test_exact_title_match_is_conservatively_omitted_from_fixed_negatives(
   tmp_path: Path,
 ) -> None:
@@ -836,6 +947,18 @@ def test_snapshot_rejects_issue_number_reused_across_works(
         issue_urls=["https://github.test/issues/999"]
       ),
       "issue URLs are not unique and sorted",
+    ),
+    (
+      lambda row: row.update(title=123),
+      "title and abstract must be canonical strings",
+    ),
+    (
+      lambda row: row.update(abstract=123),
+      "title and abstract must be canonical strings",
+    ),
+    (
+      lambda row: row.update(known_bib_keys=[123]),
+      "known bibliography keys must be a list",
     ),
   ],
 )

--- a/tests/paperbot/test_issue_negatives.py
+++ b/tests/paperbot/test_issue_negatives.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -172,6 +173,27 @@ def test_duplicate_issues_contribute_one_canonical_work(tmp_path: Path) -> None:
   assert result["duplicate_issue_count"] == 1
   assert result["active_count"] == 1
   assert row.issue_numbers == (4, 9)
+
+
+def test_duplicate_revision_tie_prefers_newer_issue_number(
+  tmp_path: Path,
+) -> None:
+  older_issue = record(abstract="Abstract from the older duplicate issue.")
+  newer_issue = record(abstract="Abstract from the newer duplicate issue.")
+
+  sync_issue_negatives(
+    config(tmp_path),
+    client=MemoryClient([
+      managed_issue(newer_issue, number=9),
+      managed_issue(older_issue, number=4),
+    ]),
+  )
+  [row] = load_issue_negative_snapshot(
+    tmp_path / "paper_relevance" / "issue_negatives.jsonl"
+  )
+
+  assert row.selected_issue_number == 9
+  assert row.abstract == newer_issue.abstract
 
 
 def test_bibliography_overlap_is_recorded_and_omitted(tmp_path: Path) -> None:
@@ -500,3 +522,360 @@ def test_strict_title_author_year_match_omits_preprint_now_in_bibliography(
   assert result["active_count"] == 0
   assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
   assert row.bibliography_keys == ("published2026",)
+
+
+def test_exact_title_match_is_conservatively_omitted_from_bibliography(
+  tmp_path: Path,
+) -> None:
+  paper = record(
+    doi="10.1000/unrelated-identifier",
+    pmid="",
+    source_id="different",
+    title="A useful paper",
+    abstract="The issue has a completely revised abstract.",
+    authors=("Another Author",),
+    updated_at="2025-06-01",
+  )
+  configuration = config(tmp_path)
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
+  assert row.bibliography_keys == ("positive2026",)
+
+
+def test_exact_title_match_is_conservatively_omitted_from_fixed_negatives(
+  tmp_path: Path,
+) -> None:
+  paper = record(
+    doi="10.1000/revised",
+    pmid="",
+    source_id="revised",
+    abstract="A later abstract with no shared identifier or input hash.",
+    authors=("Another Author",),
+    updated_at="2025-06-01",
+  )
+  configuration = config(
+    tmp_path,
+    fixed={
+      "paper_id": "pmid:99999",
+      "work_id": "pmid:99999",
+      "pmid": "99999",
+      "title": paper.title,
+      "abstract": "The frozen corpus contains an older abstract.",
+      "authors": ["Different, Person"],
+      "published_year": 2019,
+    },
+  )
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert row.omission_reasons == (OMITTED_FIXED,)
+  assert row.fixed_negative_ids == ("pmid:99999",)
+
+
+def test_overlap_on_nonrepresentative_revision_omits_whole_component(
+  tmp_path: Path,
+) -> None:
+  older = record(
+    doi="10.1000/older",
+    pmid="",
+    source_id="older",
+    title="A useful paper",
+    abstract="The historical abstract.",
+    authors=("Different Author",),
+    updated_at="2025-01-01",
+  )
+  latest = record(
+    doi="10.1000/latest",
+    pmid="",
+    source_id="latest",
+    title="A renamed paper",
+    abstract="The revised historical abstract.",
+    authors=("Different Author",),
+    updated_at="2026-01-01",
+    related_ids=("doi:10.1000/older",),
+  )
+  configuration = config(tmp_path)
+
+  result = sync_issue_negatives(
+    configuration,
+    client=MemoryClient([
+      managed_issue(older, number=1),
+      managed_issue(latest, number=2),
+    ]),
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert row.selected_issue_number == 2
+  assert row.title == latest.title
+  assert row.active is False
+  assert row.bibliography_keys == ("positive2026",)
+  assert result["active_count"] == 0
+
+
+def test_exact_input_does_not_merge_conflicting_publication_identifiers(
+  tmp_path: Path,
+) -> None:
+  first = record(
+    doi="10.1000/first",
+    pmid="",
+    source_id="first",
+    authors=("First Author",),
+  )
+  second = record(
+    doi="10.1000/second",
+    pmid="",
+    source_id="second",
+    authors=("Second Author",),
+  )
+
+  with pytest.raises(GitHubError, match="Exact SPECTER2 input.*ambiguously"):
+    sync_issue_negatives(
+      config(tmp_path),
+      client=MemoryClient([
+        managed_issue(first, number=1),
+        managed_issue(second, number=2),
+      ]),
+    )
+
+
+def test_title_fallback_does_not_merge_conflicting_native_source_ids(
+  tmp_path: Path,
+) -> None:
+  first = record(
+    doi="",
+    pmid="",
+    source_id="provider-record-one",
+    abstract="First abstract.",
+  )
+  second = record(
+    doi="",
+    pmid="",
+    source_id="provider-record-two",
+    abstract="Second abstract.",
+  )
+
+  with pytest.raises(GitHubError, match="Strict title identity.*ambiguously"):
+    sync_issue_negatives(
+      config(tmp_path),
+      client=MemoryClient([
+        managed_issue(first, number=1),
+        managed_issue(second, number=2),
+      ]),
+    )
+
+
+def test_research_square_preprint_can_merge_with_its_publication(
+  tmp_path: Path,
+) -> None:
+  preprint = PaperRecord(
+    source="research-square",
+    source_id="rs-123",
+    title="A shared preprint title",
+    abstract="The preprint abstract.",
+    authors=("Ada Lovelace",),
+    created_at="2026-01-01",
+    updated_at="2026-01-01",
+    doi="10.21203/rs.3.rs-123/v1",
+  )
+  publication = PaperRecord(
+    source="crossref",
+    source_id="10.1000/publication",
+    title=preprint.title,
+    abstract="The publication abstract.",
+    authors=preprint.authors,
+    created_at="2026-06-01",
+    updated_at="2026-06-01",
+    doi="10.1000/publication",
+  )
+
+  result = sync_issue_negatives(
+    config(tmp_path),
+    client=MemoryClient([
+      managed_issue(preprint, number=1),
+      managed_issue(publication, number=2),
+    ]),
+  )
+  [row] = load_issue_negative_snapshot(
+    tmp_path / "paper_relevance" / "issue_negatives.jsonl"
+  )
+
+  assert result["canonical_work_count"] == 1
+  assert row.issue_numbers == (1, 2)
+  assert row.selected_issue_number == 2
+
+
+@pytest.mark.parametrize("field", ["version", "updated"])
+def test_revision_order_fields_must_match_managed_hashes(
+  tmp_path: Path, field: str
+) -> None:
+  issue = managed_issue(record(version="2"))
+  meta_start = issue["body"].index("<!-- paperbot:meta ") + len(
+    "<!-- paperbot:meta "
+  )
+  meta_end = issue["body"].index(" -->", meta_start)
+  meta = json.loads(issue["body"][meta_start:meta_end])
+  meta[field] = "tampered"
+  issue["body"] = (
+    issue["body"][:meta_start]
+    + json.dumps(meta, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    + issue["body"][meta_end:]
+  )
+
+  with pytest.raises(GitHubError, match=rf"{field}.*hash"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_all_managed_field_hashes_are_required(tmp_path: Path) -> None:
+  issue = managed_issue(record())
+  meta_start = issue["body"].index("<!-- paperbot:meta ") + len(
+    "<!-- paperbot:meta "
+  )
+  meta_end = issue["body"].index(" -->", meta_start)
+  meta = json.loads(issue["body"][meta_start:meta_end])
+  del meta["field_hashes"]["venue"]
+  issue["body"] = (
+    issue["body"][:meta_start]
+    + json.dumps(meta, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    + issue["body"][meta_end:]
+  )
+
+  with pytest.raises(GitHubError, match="incomplete or invalid field hashes"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_boolean_issue_number_is_rejected(tmp_path: Path) -> None:
+  issue = managed_issue(record())
+  issue["number"] = True
+
+  with pytest.raises(GitHubError, match="missing its issue number"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_snapshot_rejects_issue_number_reused_across_works(
+  tmp_path: Path,
+) -> None:
+  configuration = config(tmp_path)
+  first = record()
+  second = record(
+    doi="10.1000/second",
+    pmid="",
+    source_id="second",
+    title="A second unrelated title",
+    abstract="A second unrelated abstract.",
+    authors=("Second Author",),
+  )
+  sync_issue_negatives(
+    configuration,
+    client=MemoryClient([
+      managed_issue(first, number=1),
+      managed_issue(second, number=2),
+    ]),
+  )
+  path = configuration.artifact_dir / "issue_negatives.jsonl"
+  rows = [
+    json.loads(line)
+    for line in path.read_text(encoding="utf-8").splitlines()
+  ]
+  rows[1]["issue_numbers"] = [1]
+  rows[1]["issue_urls"] = ["https://github.test/issues/1"]
+  rows[1]["selected_issue_number"] = 1
+  path.write_text(
+    "".join(
+      json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n"
+      for row in rows
+    ),
+    encoding="utf-8",
+  )
+
+  with pytest.raises(ValueError, match=r"GitHub issue #1 appears"):
+    load_issue_negative_snapshot(path)
+
+
+@pytest.mark.parametrize(
+  ("mutate", "message"),
+  [
+    (
+      lambda row: row.update(schema_version=True),
+      "unsupported schema",
+    ),
+    (
+      lambda row: row.update(work_id=row["work_id"].upper()),
+      "identity",
+    ),
+    (
+      lambda row: row.update(
+        aliases=[
+          alias.upper() if alias == row["work_id"] else alias
+          for alias in row["aliases"]
+        ]
+      ),
+      "aliases.*noncanonical",
+    ),
+    (
+      lambda row: row.update(issue_urls=[]),
+      "issue URLs are invalid",
+    ),
+    (
+      lambda row: row.update(
+        issue_urls=["https://github.test/issues/999"]
+      ),
+      "issue URLs are not unique and sorted",
+    ),
+  ],
+)
+def test_snapshot_requires_canonical_identity_schema_and_issue_provenance(
+  tmp_path: Path,
+  mutate: Any,
+  message: str,
+) -> None:
+  configuration = config(tmp_path)
+  sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(record())])
+  )
+  path = configuration.artifact_dir / "issue_negatives.jsonl"
+  row = json.loads(path.read_text(encoding="utf-8"))
+  mutate(row)
+  path.write_text(
+    json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+  )
+
+  with pytest.raises(ValueError, match=message):
+    load_issue_negative_snapshot(path)
+
+
+def test_malformed_fixed_negative_aliases_fail_closed(tmp_path: Path) -> None:
+  configuration = config(
+    tmp_path,
+    fixed={
+      "paper_id": "pmid:99999",
+      "work_id": "pmid:99999",
+      "pmid": "99999",
+      "title": "A fixed negative",
+      "abstract": "A fixed abstract.",
+      "authors": ["Different, Person"],
+      "published_year": 2019,
+      "aliases": "doi:10.1000/not-a-list",
+    },
+  )
+
+  with pytest.raises(ValueError, match="aliases.*must be a list"):
+    sync_issue_negatives(
+      configuration, client=MemoryClient([managed_issue(record())])
+    )

--- a/tests/paperbot/test_issue_negatives.py
+++ b/tests/paperbot/test_issue_negatives.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.paperbot.github import GitHubError, build_managed_meta, render_managed_body
+from scripts.paperbot.issue_negatives import (
+  OMITTED_BIBLIOGRAPHY,
+  OMITTED_FIXED,
+  load_issue_negative_snapshot,
+  sync_issue_negatives,
+)
+from scripts.paperbot.records import PaperRecord
+
+
+class MemoryClient:
+  def __init__(self, issues: list[dict[str, Any]]) -> None:
+    self.issues = deepcopy(issues)
+    self.labels: list[str | None] = []
+
+  def list_issues(self, *, label: str | None = "paper") -> list[dict[str, Any]]:
+    self.labels.append(label)
+    return deepcopy(self.issues)
+
+
+def record(
+  *,
+  doi: str = "10.1000/negative",
+  pmid: str = "12345",
+  source_id: str = "12345",
+  title: str = "An irrelevant paper",
+  abstract: str = "This complete abstract describes an unrelated topic.",
+  authors: tuple[str, ...] = ("Ada Lovelace",),
+  updated_at: str = "2026-07-22",
+  version: str = "",
+  related_ids: tuple[str, ...] = (),
+) -> PaperRecord:
+  return PaperRecord(
+    source="pubmed",
+    source_id=source_id,
+    title=title,
+    abstract=abstract,
+    authors=authors,
+    venue="Example journal",
+    created_at="2026-07-20",
+    updated_at=updated_at,
+    doi=doi,
+    pmid=pmid,
+    version=version,
+    related_ids=related_ids,
+  )
+
+
+def managed_issue(
+  paper: PaperRecord,
+  *,
+  number: int = 1,
+  state: str = "closed",
+  labels: tuple[str, ...] = ("paper", "AI-generated", "negative"),
+  login: str = "github-actions[bot]",
+  prefix: str = "",
+  suffix: str = "",
+) -> dict[str, Any]:
+  bibtex = (
+    "@article{lovelace2026,\n"
+    f"  title = {{{paper.title}}},\n"
+    f"  abstract = {{{paper.abstract}}},\n"
+    "}"
+  )
+  meta = build_managed_meta(
+    paper, 0.9, bibtex, "lovelace2026", model_hash="model"
+  )
+  body = render_managed_body(
+    paper, 0.9, bibtex, "lovelace2026", meta=meta
+  )
+  return {
+    "number": number,
+    "node_id": f"ISSUE_{number}",
+    "title": paper.title,
+    "body": f"{prefix}{body}{suffix}",
+    "state": state,
+    "html_url": f"https://github.test/issues/{number}",
+    "labels": [{"name": label} for label in labels],
+    "user": {"login": login},
+  }
+
+
+def config(
+  tmp_path: Path,
+  *,
+  bibliography_doi: str = "10.1000/positive",
+  fixed: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+  bibliography = tmp_path / "bibliography.bib"
+  bibliography.write_text(
+    "@article{positive2026,\n"
+    "  title = {A useful paper},\n"
+    "  author = {Hopper, Grace},\n"
+    "  year = {2026},\n"
+    "  abstract = {A useful abstract about the target field.},\n"
+    f"  doi = {{{bibliography_doi}}},\n"
+    "}\n",
+    encoding="utf-8",
+  )
+  artifacts = tmp_path / "paper_relevance"
+  artifacts.mkdir()
+  negative_corpus = artifacts / "pubmed_negatives_v1.jsonl"
+  if fixed is None:
+    negative_corpus.write_text("", encoding="utf-8")
+  else:
+    import json
+
+    negative_corpus.write_text(
+      json.dumps(fixed, sort_keys=True) + "\n", encoding="utf-8"
+    )
+  return SimpleNamespace(
+    repository="delalamo/SKM",
+    bibliography_path=bibliography,
+    artifact_dir=artifacts,
+    negative_corpus_path=negative_corpus,
+  )
+
+
+def test_sync_selects_only_closed_bot_managed_negative_issues(
+  tmp_path: Path,
+) -> None:
+  paper = record()
+  selected = managed_issue(
+    paper,
+    number=1,
+    labels=("paper", "NeGaTiVe"),
+    prefix="User note before.\n",
+    suffix="\nUser note after.",
+  )
+  client = MemoryClient(
+    [
+      selected,
+      managed_issue(paper, number=2, state="open"),
+      managed_issue(paper, number=3, labels=("paper",)),
+      managed_issue(paper, number=4, login="someone"),
+    ]
+  )
+
+  result = sync_issue_negatives(config(tmp_path), client=client)
+  snapshot = load_issue_negative_snapshot(
+    tmp_path / "paper_relevance" / "issue_negatives.jsonl"
+  )
+
+  assert client.labels == [None]
+  assert result["eligible_issue_count"] == 1
+  assert result["active_count"] == 1
+  assert snapshot[0].issue_numbers == (1,)
+  assert snapshot[0].abstract == paper.abstract
+  assert "User note" not in snapshot[0].abstract
+
+
+def test_duplicate_issues_contribute_one_canonical_work(tmp_path: Path) -> None:
+  paper = record()
+  client = MemoryClient(
+    [managed_issue(paper, number=9), managed_issue(paper, number=4)]
+  )
+
+  result = sync_issue_negatives(config(tmp_path), client=client)
+  [row] = load_issue_negative_snapshot(
+    tmp_path / "paper_relevance" / "issue_negatives.jsonl"
+  )
+
+  assert result["duplicate_issue_count"] == 1
+  assert result["active_count"] == 1
+  assert row.issue_numbers == (4, 9)
+
+
+def test_bibliography_overlap_is_recorded_and_omitted(tmp_path: Path) -> None:
+  paper = record()
+  configuration = config(tmp_path, bibliography_doi=paper.doi)
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert result["omission_counts"] == {OMITTED_BIBLIOGRAPHY: 1}
+  assert row.active is False
+  assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
+  assert row.bibliography_keys == ("positive2026",)
+
+
+def test_fixed_negative_overlap_receives_no_extra_weight(tmp_path: Path) -> None:
+  paper = record()
+  configuration = config(
+    tmp_path,
+    fixed={
+      "paper_id": "pmid:12345",
+      "work_id": f"doi:{paper.doi}",
+      "pmid": "12345",
+      "doi": paper.doi,
+      "title": paper.title,
+      "abstract": paper.abstract,
+      "authors": ["Lovelace, Ada"],
+      "published_year": 2026,
+    },
+  )
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert result["omission_counts"] == {OMITTED_FIXED: 1}
+  assert row.omission_reasons == (OMITTED_FIXED,)
+  assert row.fixed_negative_ids == (f"doi:{paper.doi}",)
+
+
+def test_unchanged_sync_is_byte_identical(tmp_path: Path) -> None:
+  configuration = config(tmp_path)
+  client = MemoryClient([managed_issue(record())])
+
+  sync_issue_negatives(configuration, client=client)
+  path = configuration.artifact_dir / "issue_negatives.jsonl"
+  first = path.read_bytes()
+  sync_issue_negatives(configuration, client=client)
+
+  assert path.read_bytes() == first
+
+
+def test_managed_title_hash_mismatch_fails_closed(tmp_path: Path) -> None:
+  issue = managed_issue(record())
+  issue["title"] = "Edited title"
+
+  with pytest.raises(GitHubError, match="title.*hash"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_repeated_issue_number_with_different_content_fails(tmp_path: Path) -> None:
+  first = managed_issue(record(), number=7)
+  second = managed_issue(
+    record(
+      doi="10.1000/other",
+      title="Another irrelevant paper",
+      abstract="Another complete and unrelated abstract.",
+    ),
+    number=7,
+  )
+
+  with pytest.raises(GitHubError, match="appeared more than once"):
+    sync_issue_negatives(
+      config(tmp_path), client=MemoryClient([first, second])
+    )
+
+
+def test_workflow_repository_mismatch_fails_before_reading_issues(
+  tmp_path: Path,
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  client = MemoryClient([managed_issue(record())])
+  monkeypatch.setenv("GITHUB_REPOSITORY", "someone/untrusted-fork")
+
+  with pytest.raises(ValueError, match="does not match GITHUB_REPOSITORY"):
+    sync_issue_negatives(config(tmp_path), client=client)
+
+  assert client.labels == []
+
+
+def test_unrelated_actions_issue_with_negative_label_is_ignored(
+  tmp_path: Path,
+) -> None:
+  unrelated = {
+    "number": 50,
+    "node_id": "ISSUE_50",
+    "title": "A deployment failed",
+    "body": "This is not a paperbot issue.",
+    "state": "closed",
+    "html_url": "https://github.test/issues/50",
+    "labels": [{"name": "negative"}],
+    "user": {"login": "github-actions[bot]"},
+  }
+
+  result = sync_issue_negatives(
+    config(tmp_path), client=MemoryClient([unrelated])
+  )
+
+  assert result["eligible_issue_count"] == 0
+  assert result["canonical_work_count"] == 0
+
+
+def test_lifecycle_reopen_and_label_removal_deactivate_on_next_sync(
+  tmp_path: Path,
+) -> None:
+  configuration = config(tmp_path)
+  issue = managed_issue(record())
+
+  sync_issue_negatives(configuration, client=MemoryClient([issue]))
+  assert len(load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )) == 1
+
+  issue["state"] = "open"
+  sync_issue_negatives(configuration, client=MemoryClient([issue]))
+  assert load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  ) == []
+
+  issue["state"] = "closed"
+  issue["labels"] = [{"name": "paper"}]
+  sync_issue_negatives(configuration, client=MemoryClient([issue]))
+  assert load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  ) == []
+
+  issue["labels"].append({"name": "NEGATIVE"})
+  sync_issue_negatives(configuration, client=MemoryClient([issue]))
+  assert len(load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )) == 1
+
+
+@pytest.mark.parametrize(
+  ("edit", "message"),
+  [
+    (
+      lambda issue: issue.update(
+        body=issue["body"].replace(
+          "<!-- paperbot:managed:end -->", ""
+        )
+      ),
+      "complete paperbot block",
+    ),
+    (
+      lambda issue: issue.update(
+        body=issue["body"].replace(
+          "## BibTeX", "## Abstract\n\nInjected text\n\n## BibTeX"
+        )
+      ),
+      "exactly one abstract",
+    ),
+    (
+      lambda issue: issue.update(
+        body=issue["body"].replace(
+          record().abstract, "An edited abstract."
+        )
+      ),
+      "abstract.*hash",
+    ),
+  ],
+)
+def test_malformed_managed_negatives_fail_closed(
+  tmp_path: Path, edit: Any, message: str
+) -> None:
+  issue = managed_issue(record())
+  edit(issue)
+
+  with pytest.raises(GitHubError, match=message):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_identifier_hash_mismatch_fails_closed(tmp_path: Path) -> None:
+  issue = managed_issue(record())
+  marker = '"identifiers":"'
+  position = issue["body"].index(marker) + len(marker)
+  issue["body"] = (
+    issue["body"][:position] + "0" * 64 + issue["body"][position + 64 :]
+  )
+
+  with pytest.raises(GitHubError, match="identifiers.*hash"):
+    sync_issue_negatives(config(tmp_path), client=MemoryClient([issue]))
+
+
+def test_transitive_aliases_merge_once_and_keep_latest_revision(
+  tmp_path: Path,
+) -> None:
+  first = record(
+    doi="10.1101/2026.01.01.1",
+    pmid="",
+    source_id="preprint",
+    updated_at="2026-07-20",
+  )
+  middle = record(
+    doi="",
+    pmid="222",
+    source_id="pubmed",
+    abstract="A revised but still irrelevant abstract.",
+    related_ids=("doi:10.1101/2026.01.01.1",),
+    updated_at="2026-07-21",
+    version="2",
+  )
+  latest = record(
+    doi="10.1000/publication",
+    pmid="",
+    source_id="publication",
+    abstract="The latest irrelevant abstract.",
+    related_ids=("pmid:222",),
+    updated_at="2026-07-22",
+    version="3",
+  )
+  configuration = config(tmp_path)
+
+  result = sync_issue_negatives(
+    configuration,
+    client=MemoryClient([
+      managed_issue(latest, number=13),
+      managed_issue(first, number=11),
+      managed_issue(middle, number=12),
+    ]),
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["canonical_work_count"] == 1
+  assert result["duplicate_issue_count"] == 2
+  assert row.issue_numbers == (11, 12, 13)
+  assert row.selected_issue_number == 13
+  assert row.abstract == latest.abstract
+
+
+def test_title_fallback_with_conflicting_publication_dois_fails(
+  tmp_path: Path,
+) -> None:
+  first = record(
+    doi="10.1000/first",
+    pmid="",
+    source_id="first",
+    abstract="First abstract.",
+  )
+  second = record(
+    doi="10.1000/second",
+    pmid="",
+    source_id="second",
+    abstract="Second abstract.",
+  )
+
+  with pytest.raises(GitHubError, match="ambiguously matches"):
+    sync_issue_negatives(
+      config(tmp_path),
+      client=MemoryClient([
+        managed_issue(first, number=1),
+        managed_issue(second, number=2),
+      ]),
+    )
+
+
+def test_same_node_id_with_conflicting_issue_numbers_fails(tmp_path: Path) -> None:
+  first = managed_issue(record(), number=1)
+  second = managed_issue(
+    record(
+      doi="10.1000/second",
+      pmid="",
+      source_id="second",
+      title="A different paper",
+      abstract="A different abstract.",
+    ),
+    number=2,
+  )
+  second["node_id"] = first["node_id"]
+
+  with pytest.raises(GitHubError, match="node.*conflicting"):
+    sync_issue_negatives(
+      config(tmp_path), client=MemoryClient([first, second])
+    )
+
+
+def test_strict_title_author_year_match_omits_preprint_now_in_bibliography(
+  tmp_path: Path,
+) -> None:
+  paper = record(
+    doi="10.1101/2026.01.01.1",
+    pmid="",
+    source_id="preprint",
+    abstract="A preprint abstract that differs from the bibliography.",
+  )
+  configuration = config(tmp_path)
+  configuration.bibliography_path.write_text(
+    "@article{published2026,\n"
+    "  title = {An irrelevant paper},\n"
+    "  author = {Lovelace, Ada},\n"
+    "  year = {2026},\n"
+    "  abstract = {The later journal abstract.},\n"
+    "  doi = {10.1000/publication},\n"
+    "}\n",
+    encoding="utf-8",
+  )
+
+  result = sync_issue_negatives(
+    configuration, client=MemoryClient([managed_issue(paper)])
+  )
+  [row] = load_issue_negative_snapshot(
+    configuration.artifact_dir / "issue_negatives.jsonl"
+  )
+
+  assert result["active_count"] == 0
+  assert row.omission_reasons == (OMITTED_BIBLIOGRAPHY,)
+  assert row.bibliography_keys == ("published2026",)

--- a/tests/paperbot/test_model.py
+++ b/tests/paperbot/test_model.py
@@ -26,6 +26,7 @@ from scripts.paperbot.model import (  # noqa: E402
   NegativePaper,
   StaleModelError,
   load_negative_corpus,
+  load_model,
   negative_category_family,
   negative_selection_key,
   model_errors,
@@ -36,7 +37,9 @@ from scripts.paperbot.model import (  # noqa: E402
   validate_negative_metadata,
   check_model,
   _dependency_versions,
+  _array_hash,
   _model_hash,
+  _records_hash,
 )
 from scripts.paperbot.bibliography import embedding_input_hash  # noqa: E402
 from scripts.paperbot.issue_negatives import (  # noqa: E402
@@ -414,6 +417,30 @@ class ArtifactTests(unittest.TestCase):
     )
     check_model(self.bib, self.artifacts, strict_negative_quotas=False)
 
+  def test_fit_omits_identifierless_issue_with_exact_bibliography_title(self) -> None:
+    # Old managed issues do not always carry stable IDs or a compatible
+    # title/author/year alias. Exact normalized-title equality must still
+    # prevent a revised abstract from turning a positive into a negative.
+    self.write_issue_negatives(self.issue_negative(
+      work_id="fallback:unrelated-legacy-identity",
+      title="A useful paper",
+      abstract="A later abstract revision with completely different text.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(
+      manifest["issue_negative_omission_counts"],
+      {"bibliography_overlap": 1},
+    )
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
   def test_fit_omits_issue_negative_already_in_the_fixed_corpus(self) -> None:
     self.write_issue_negatives(self.issue_negative(
       work_id="pmid:12345",
@@ -431,6 +458,78 @@ class ArtifactTests(unittest.TestCase):
     self.assertEqual(manifest["issue_negative_count"], 0)
     self.assertEqual(manifest["effective_negative_count"], 1)
     self.assertEqual(manifest["issue_negative_fixed_overlap_count"], 1)
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_fit_omits_fixed_negative_with_changed_identity_and_abstract(self) -> None:
+    self.write_issue_negatives(self.issue_negative(
+      work_id="fallback:legacy-fixed-negative",
+      title="Remote stars",
+      abstract="A revised copy whose text no longer matches the frozen record.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(manifest["issue_negative_fixed_overlap_count"], 1)
+    self.assertEqual(manifest["effective_negative_count"], 1)
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_removed_and_readded_issue_reuses_one_append_only_row(self) -> None:
+    feedback = self.issue_negative(
+      work_id="doi:10.9999/irrelevant",
+      title="An irrelevant clinical report",
+      abstract="This report concerns an unrelated therapeutic intervention.",
+    )
+    self.write_issue_negatives(feedback)
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.write_issue_negatives()
+    removed = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    removed_rows = [
+      json.loads(line)
+      for line in (self.artifacts / ISSUE_NEGATIVE_MANIFEST)
+      .read_text(encoding="utf-8")
+      .splitlines()
+    ]
+    self.assertEqual(removed["issue_negative_count"], 0)
+    self.assertEqual(len(removed_rows), 1)
+    self.assertFalse(removed_rows[0]["active"])
+
+    self.write_issue_negatives(feedback)
+    encoder = self.FakeEncoder()
+    with patch.object(encoder, "embed", wraps=encoder.embed) as embed:
+      restored = refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=encoder,
+        strict_negative_quotas=False,
+      )
+    restored_rows = [
+      json.loads(line)
+      for line in (self.artifacts / ISSUE_NEGATIVE_MANIFEST)
+      .read_text(encoding="utf-8")
+      .splitlines()
+    ]
+    self.assertEqual(restored["issue_negative_count"], 1)
+    self.assertEqual(len(restored_rows), 1)
+    self.assertEqual(restored_rows[0]["row"], 0)
+    self.assertTrue(restored_rows[0]["active"])
+    embed.assert_not_called()
     check_model(self.bib, self.artifacts, strict_negative_quotas=False)
 
   def test_check_model_accepts_legacy_artifacts_as_empty_feedback(self) -> None:
@@ -471,6 +570,70 @@ class ArtifactTests(unittest.TestCase):
     )
     self.assertEqual(checked["model_hash"], manifest["model_hash"])
 
+  def test_check_rejects_issue_artifacts_orphaned_beside_legacy_model(
+    self,
+  ) -> None:
+    import numpy as np
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    manifest_path = self.artifacts / "model_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    with np.load(self.artifacts / "classifier.npz", allow_pickle=False) as model:
+      coefficients = np.asarray(model["coef"], dtype=np.float64)
+      intercept = float(np.asarray(model["intercept"])[0])
+    for field in list(manifest):
+      if field.startswith("issue_negative_"):
+        manifest.pop(field)
+    manifest.pop("effective_negative_count")
+    manifest["model_hash"] = _model_hash(
+      coefficients,
+      intercept,
+      manifest["bibliography_hash"],
+      manifest["negative_corpus_file_hash"],
+      manifest["negative_metadata_file_hash"],
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    errors = model_errors(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+
+    self.assertTrue(
+      any("exist beside a legacy model manifest" in error for error in errors),
+      errors,
+    )
+
+  def test_refresh_refuses_to_drop_a_missing_synchronized_snapshot(
+    self,
+  ) -> None:
+    self.write_issue_negatives(self.issue_negative(
+      work_id="doi:10.9999/irrelevant",
+      title="An irrelevant clinical report",
+      abstract="This report concerns an unrelated therapeutic intervention.",
+    ))
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    (self.artifacts / ISSUE_NEGATIVE_CORPUS).unlink()
+
+    with self.assertRaisesRegex(
+      ValueError, "synchronized issue-negative snapshot is missing"
+    ):
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=self.FakeEncoder(),
+        strict_negative_quotas=False,
+      )
+
   def test_check_detects_issue_negative_artifact_tampering(self) -> None:
     import numpy as np
 
@@ -497,6 +660,120 @@ class ArtifactTests(unittest.TestCase):
       any("issue_negative_matrix_hash" in error for error in errors),
       errors,
     )
+
+  def test_refresh_rejects_non_normalized_encoder_output(self) -> None:
+    class NonNormalizedEncoder:
+      def embed(self, documents):
+        import numpy as np
+
+        return np.full(
+          (len(documents), EMBEDDING_DIMENSION),
+          1.0,
+          dtype=np.float32,
+        )
+
+    with self.assertRaisesRegex(ValueError, "not L2-normalized"):
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=NonNormalizedEncoder(),
+        strict_negative_quotas=False,
+      )
+
+  def test_check_rejects_noncanonical_append_only_manifest(self) -> None:
+    import numpy as np
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    rows_path = self.artifacts / "positive_manifest.jsonl"
+    matrix_path = self.artifacts / "positive_embeddings.npy"
+    model_manifest_path = self.artifacts / "model_manifest.json"
+    rows = [json.loads(line) for line in rows_path.read_text().splitlines()]
+    duplicate = {**rows[0], "row": 1, "active": False}
+    rows.append(duplicate)
+    matrix = np.vstack([np.load(matrix_path, allow_pickle=False)] * 2)
+    rows_path.write_text(
+      "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+      encoding="utf-8",
+    )
+    np.save(matrix_path, matrix, allow_pickle=False)
+    model_manifest = json.loads(model_manifest_path.read_text())
+    model_manifest["positive_rows"] = len(rows)
+    model_manifest["positive_manifest_hash"] = _records_hash(rows)
+    model_manifest["positive_matrix_hash"] = _array_hash(matrix)
+    model_manifest_path.write_text(json.dumps(model_manifest), encoding="utf-8")
+
+    errors = model_errors(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+    self.assertTrue(any("duplicate identifier" in error for error in errors), errors)
+
+  def test_check_rejects_noncanonical_embedding_dtype(self) -> None:
+    import numpy as np
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    matrix_path = self.artifacts / "positive_embeddings.npy"
+    model_manifest_path = self.artifacts / "model_manifest.json"
+    matrix = np.load(matrix_path, allow_pickle=False).astype(np.float64)
+    np.save(matrix_path, matrix, allow_pickle=False)
+    model_manifest = json.loads(model_manifest_path.read_text())
+    model_manifest["positive_matrix_hash"] = _array_hash(matrix)
+    model_manifest_path.write_text(json.dumps(model_manifest), encoding="utf-8")
+
+    errors = model_errors(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+    self.assertTrue(any("expected float32" in error for error in errors), errors)
+
+  def test_check_rejects_ambiguous_classifier_archive(self) -> None:
+    import numpy as np
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    classifier_path = self.artifacts / "classifier.npz"
+    with np.load(classifier_path, allow_pickle=False) as stored:
+      coefficients = stored["coef"].copy()
+      intercept = stored["intercept"].copy()
+      classes = stored["classes"].copy()
+    np.savez(
+      classifier_path,
+      coef=coefficients,
+      intercept=np.concatenate([intercept, [999.0]]),
+      classes=classes,
+    )
+
+    errors = model_errors(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+    self.assertTrue(any("intercept has shape" in error for error in errors), errors)
+
+  def test_load_model_rejects_manifest_classifier_hash_mismatch(self) -> None:
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    manifest_path = self.artifacts / "model_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["model_hash"] = "a" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with self.assertRaisesRegex(ValueError, "does not match"):
+      load_model(self.artifacts)
 
   def test_positive_row_is_stable_when_abstract_changes(self) -> None:
     refresh_model(self.bib, self.artifacts, encoder=self.FakeEncoder(), strict_negative_quotas=False)
@@ -601,6 +878,62 @@ class ArtifactTests(unittest.TestCase):
         )
         self.assertTrue(any(field in error for error in errors), errors)
     manifest_path.write_text(json.dumps(original))
+
+  def test_model_contract_rejects_json_type_aliases(self) -> None:
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    manifest_path = self.artifacts / "model_manifest.json"
+    original = json.loads(manifest_path.read_text(encoding="utf-8"))
+    cases = {
+      "schema": lambda value: value.update(schema=True),
+      "embedding": lambda value: value["embedding"].update(
+        dimension=float(EMBEDDING_DIMENSION)
+      ),
+      "classifier": lambda value: value["classifier"].update(
+        fit_intercept=1
+      ),
+    }
+
+    for expected, mutate in cases.items():
+      with self.subTest(expected=expected):
+        changed = json.loads(json.dumps(original))
+        mutate(changed)
+        manifest_path.write_text(json.dumps(changed), encoding="utf-8")
+        errors = model_errors(
+          self.bib, self.artifacts, strict_negative_quotas=False
+        )
+        self.assertTrue(any(expected in error for error in errors), errors)
+        with self.assertRaisesRegex(ValueError, "model specification"):
+          load_model(self.artifacts)
+
+    manifest_path.write_text(json.dumps(original), encoding="utf-8")
+
+  def test_refresh_does_not_reuse_type_aliased_embedding_contract(self) -> None:
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    manifest_path = self.artifacts / "model_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["embedding"]["dimension"] = float(EMBEDDING_DIMENSION)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    encoder = self.FakeEncoder()
+    with patch.object(encoder, "embed", wraps=encoder.embed) as embed:
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=encoder,
+        strict_negative_quotas=False,
+      )
+
+    self.assertEqual(sum(len(call.args[0]) for call in embed.call_args_list), 2)
 
   def test_check_compares_recorded_training_metadata_to_refit(self) -> None:
     refresh_model(
@@ -710,6 +1043,33 @@ class ArtifactTests(unittest.TestCase):
     np.save(matrix_path, matrix, allow_pickle=False)
 
     with self.assertRaisesRegex(ValueError, "Refusing to reuse corrupt positive"):
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=self.FakeEncoder(),
+        strict_negative_quotas=False,
+      )
+
+  def test_refresh_refuses_hash_consistent_but_invalid_old_manifest(self) -> None:
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    rows_path = self.artifacts / "positive_manifest.jsonl"
+    manifest_path = self.artifacts / "model_manifest.json"
+    rows = [json.loads(line) for line in rows_path.read_text().splitlines()]
+    rows[0]["active"] = "yes"
+    rows_path.write_text(
+      "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+      encoding="utf-8",
+    )
+    manifest = json.loads(manifest_path.read_text())
+    manifest["positive_manifest_hash"] = _records_hash(rows)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with self.assertRaisesRegex(ValueError, "invalid active flag"):
       refresh_model(
         self.bib,
         self.artifacts,

--- a/tests/paperbot/test_model.py
+++ b/tests/paperbot/test_model.py
@@ -41,7 +41,10 @@ from scripts.paperbot.model import (  # noqa: E402
   _model_hash,
   _records_hash,
 )
-from scripts.paperbot.bibliography import embedding_input_hash  # noqa: E402
+from scripts.paperbot.bibliography import (  # noqa: E402
+  embedding_input_hash,
+  normalize_title,
+)
 from scripts.paperbot.issue_negatives import (  # noqa: E402
   ISSUE_NEGATIVE_CORPUS,
   ISSUE_NEGATIVE_MANIFEST,
@@ -260,6 +263,9 @@ class ArtifactTests(unittest.TestCase):
       }) + "\n",
       encoding="utf-8",
     )
+    # Even an empty feedback corpus must come from an explicit synchronization.
+    # refresh-model must never manufacture an authoritative empty snapshot.
+    self.write_issue_negatives()
 
   def tearDown(self) -> None:
     self.temporary.cleanup()
@@ -272,8 +278,12 @@ class ArtifactTests(unittest.TestCase):
     abstract: str,
     issue_number: int = 101,
     aliases: tuple[str, ...] = (),
+    known_bib_keys: tuple[str, ...] = (),
+    component_titles: tuple[str, ...] = (),
+    component_input_hashes: tuple[str, ...] = (),
   ) -> IssueNegativeRecord:
     normalized_aliases = tuple(sorted({work_id, *aliases}))
+    input_hash = embedding_input_hash(title, abstract)
     return IssueNegativeRecord(
       schema_version=1,
       work_id=work_id,
@@ -283,11 +293,18 @@ class ArtifactTests(unittest.TestCase):
       selected_issue_number=issue_number,
       title=title,
       abstract=abstract,
-      input_hash=embedding_input_hash(title, abstract),
+      input_hash=input_hash,
       metadata_hash=hashlib.sha256(
         f"{work_id}:{issue_number}".encode("utf-8")
       ).hexdigest(),
       active=True,
+      known_bib_keys=tuple(sorted(known_bib_keys)),
+      component_titles=tuple(sorted(
+        component_titles or (normalize_title(title),)
+      )),
+      component_input_hashes=tuple(sorted(
+        component_input_hashes or (input_hash,)
+      )),
     )
 
   def write_issue_negatives(
@@ -301,6 +318,19 @@ class ArtifactTests(unittest.TestCase):
       ),
       encoding="utf-8",
     )
+
+  def test_initial_refresh_requires_an_explicit_issue_sync(self) -> None:
+    (self.artifacts / ISSUE_NEGATIVE_CORPUS).unlink()
+
+    with self.assertRaisesRegex(
+      ValueError, "synchronized issue-negative snapshot is missing"
+    ):
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=self.FakeEncoder(),
+        strict_negative_quotas=False,
+      )
 
   def test_refresh_check_and_stale_detection(self) -> None:
     manifest = refresh_model(
@@ -440,6 +470,153 @@ class ArtifactTests(unittest.TestCase):
       {"bibliography_overlap": 1},
     )
     check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_fit_omits_issue_matching_nonrepresentative_bibliography_title(
+    self,
+  ) -> None:
+    self.bib.write_text(
+      "@misc{preprint,\n"
+      " title={Older preprint title},\n"
+      " author={Smith, A},\n"
+      " year={2023},\n"
+      " abstract={The preprint abstract.},\n"
+      " doi={10.21203/rs.3.rs-123/v1},\n"
+      " relateddoi={10.9999/published}\n"
+      "}\n"
+      "@article{published,\n"
+      " title={New publication title},\n"
+      " author={Smith, A},\n"
+      " year={2024},\n"
+      " abstract={The final publication abstract is longer.},\n"
+      " doi={10.9999/published}\n"
+      "}\n",
+      encoding="utf-8",
+    )
+    self.write_issue_negatives(self.issue_negative(
+      work_id="fallback:unrelated-legacy-identity",
+      title="Older preprint title",
+      abstract="A later issue abstract with unrelated identifiers.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(
+      manifest["issue_negative_omission_counts"],
+      {"bibliography_overlap": 1},
+    )
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_fit_omits_drifted_issue_with_known_bibliography_key(self) -> None:
+    self.write_issue_negatives(self.issue_negative(
+      work_id="fallback:drifted-legacy-identity",
+      title="A completely drifted title",
+      abstract="Neither current text nor identifiers match the bibliography.",
+      known_bib_keys=("positive",),
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(
+      manifest["issue_negative_omission_counts"],
+      {"bibliography_overlap": 1},
+    )
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_inactive_overlap_provenance_is_recomputed_from_all_components(
+    self,
+  ) -> None:
+    feedback = self.issue_negative(
+      work_id="fallback:renamed-legacy-identity",
+      title="A renamed issue title",
+      abstract="A renamed issue abstract.",
+      component_titles=(
+        normalize_title("A renamed issue title"),
+        normalize_title("A useful paper"),
+      ),
+    )
+    self.write_issue_negatives(replace(
+      feedback,
+      active=False,
+      omission_reasons=("bibliography_overlap",),
+      bibliography_keys=("positive",),
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(manifest["issue_negative_bibliography_overlap_count"], 1)
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_overlap_recomputation_uses_collector_title_normalization(self) -> None:
+    self.bib.write_text(
+      self.bib.read_text(encoding="utf-8").replace(
+        "title={A useful paper}",
+        "title={<i>A useful paper</i>}",
+      ),
+      encoding="utf-8",
+    )
+    feedback = self.issue_negative(
+      work_id="fallback:formatted-title",
+      title="A useful paper",
+      abstract="A later issue abstract.",
+    )
+    self.write_issue_negatives(replace(
+      feedback,
+      active=False,
+      omission_reasons=("bibliography_overlap",),
+      bibliography_keys=("positive",),
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(manifest["issue_negative_bibliography_overlap_count"], 1)
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_inactive_false_overlap_provenance_fails_closed(self) -> None:
+    feedback = self.issue_negative(
+      work_id="doi:10.9999/actually-irrelevant",
+      title="An actually irrelevant paper",
+      abstract="This is not represented in either training corpus.",
+    )
+    self.write_issue_negatives(replace(
+      feedback,
+      active=False,
+      omission_reasons=("bibliography_overlap",),
+      bibliography_keys=("nonexistent-key",),
+    ))
+
+    with self.assertRaisesRegex(
+      ValueError, "overlap provenance is stale or invalid"
+    ):
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=self.FakeEncoder(),
+        strict_negative_quotas=False,
+      )
 
   def test_fit_omits_issue_negative_already_in_the_fixed_corpus(self) -> None:
     self.write_issue_negatives(self.issue_negative(
@@ -1028,7 +1205,7 @@ class ArtifactTests(unittest.TestCase):
     )
     self.assertTrue(any("deterministic refit" in error for error in errors))
 
-  def test_refresh_refuses_to_reuse_corrupt_embedding_matrix(self) -> None:
+  def test_refresh_rebuilds_a_corrupt_embedding_matrix(self) -> None:
     import numpy as np
 
     refresh_model(
@@ -1042,15 +1219,22 @@ class ArtifactTests(unittest.TestCase):
     matrix[0, 0] += 0.25
     np.save(matrix_path, matrix, allow_pickle=False)
 
-    with self.assertRaisesRegex(ValueError, "Refusing to reuse corrupt positive"):
+    encoder = self.FakeEncoder()
+    with patch.object(encoder, "embed", wraps=encoder.embed) as embed:
       refresh_model(
         self.bib,
         self.artifacts,
-        encoder=self.FakeEncoder(),
+        encoder=encoder,
         strict_negative_quotas=False,
       )
+    self.assertEqual(sum(len(call.args[0]) for call in embed.call_args_list), 2)
+    check_model(
+      self.bib,
+      self.artifacts,
+      strict_negative_quotas=False,
+    )
 
-  def test_refresh_refuses_hash_consistent_but_invalid_old_manifest(self) -> None:
+  def test_refresh_rebuilds_hash_consistent_but_invalid_old_manifest(self) -> None:
     refresh_model(
       self.bib,
       self.artifacts,
@@ -1069,13 +1253,88 @@ class ArtifactTests(unittest.TestCase):
     manifest["positive_manifest_hash"] = _records_hash(rows)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    with self.assertRaisesRegex(ValueError, "invalid active flag"):
+    encoder = self.FakeEncoder()
+    with patch.object(encoder, "embed", wraps=encoder.embed) as embed:
       refresh_model(
         self.bib,
         self.artifacts,
-        encoder=self.FakeEncoder(),
+        encoder=encoder,
         strict_negative_quotas=False,
       )
+    self.assertEqual(sum(len(call.args[0]) for call in embed.call_args_list), 2)
+
+  def test_refresh_recovers_after_an_interrupted_artifact_commit(self) -> None:
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    self.bib.write_text(
+      "@article{positive,\n"
+      " title={A useful paper revised},\n"
+      " author={Smith, A},\n"
+      " year={2024},\n"
+      " abstract={Useful biology result.},\n"
+      " doi={10.1234/useful}\n"
+      "}\n",
+      encoding="utf-8",
+    )
+
+    with patch(
+      "scripts.paperbot.model._atomic_write_jsonl",
+      side_effect=OSError("simulated interruption"),
+    ):
+      with self.assertRaisesRegex(OSError, "simulated interruption"):
+        refresh_model(
+          self.bib,
+          self.artifacts,
+          encoder=self.FakeEncoder(),
+          strict_negative_quotas=False,
+        )
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    check_model(
+      self.bib,
+      self.artifacts,
+      strict_negative_quotas=False,
+    )
+
+  def test_title_formatting_change_reembeds_the_exact_specter_input(self) -> None:
+    self.bib.write_text(
+      self.bib.read_text(encoding="utf-8").replace(
+        "A useful paper", "Alpha-Fold"
+      ),
+      encoding="utf-8",
+    )
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    self.bib.write_text(
+      self.bib.read_text(encoding="utf-8").replace(
+        "Alpha-Fold", "Alpha Fold"
+      ),
+      encoding="utf-8",
+    )
+
+    encoder = self.FakeEncoder()
+    with patch.object(encoder, "embed", wraps=encoder.embed) as embed:
+      refresh_model(
+        self.bib,
+        self.artifacts,
+        encoder=encoder,
+        strict_negative_quotas=False,
+      )
+
+    self.assertEqual(sum(len(call.args[0]) for call in embed.call_args_list), 1)
 
   def test_refresh_reembeds_when_manifest_hash_provenance_is_incomplete(self) -> None:
     refresh_model(

--- a/tests/paperbot/test_model.py
+++ b/tests/paperbot/test_model.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -34,6 +36,14 @@ from scripts.paperbot.model import (  # noqa: E402
   validate_negative_metadata,
   check_model,
   _dependency_versions,
+  _model_hash,
+)
+from scripts.paperbot.bibliography import embedding_input_hash  # noqa: E402
+from scripts.paperbot.issue_negatives import (  # noqa: E402
+  ISSUE_NEGATIVE_CORPUS,
+  ISSUE_NEGATIVE_MANIFEST,
+  ISSUE_NEGATIVE_MATRIX,
+  IssueNegativeRecord,
 )
 
 
@@ -251,6 +261,44 @@ class ArtifactTests(unittest.TestCase):
   def tearDown(self) -> None:
     self.temporary.cleanup()
 
+  def issue_negative(
+    self,
+    *,
+    work_id: str,
+    title: str,
+    abstract: str,
+    issue_number: int = 101,
+    aliases: tuple[str, ...] = (),
+  ) -> IssueNegativeRecord:
+    normalized_aliases = tuple(sorted({work_id, *aliases}))
+    return IssueNegativeRecord(
+      schema_version=1,
+      work_id=work_id,
+      aliases=normalized_aliases,
+      issue_numbers=(issue_number,),
+      issue_urls=(f"https://github.com/delalamo/SKM/issues/{issue_number}",),
+      selected_issue_number=issue_number,
+      title=title,
+      abstract=abstract,
+      input_hash=embedding_input_hash(title, abstract),
+      metadata_hash=hashlib.sha256(
+        f"{work_id}:{issue_number}".encode("utf-8")
+      ).hexdigest(),
+      active=True,
+    )
+
+  def write_issue_negatives(
+    self, *records: IssueNegativeRecord
+  ) -> None:
+    path = self.artifacts / ISSUE_NEGATIVE_CORPUS
+    path.write_text(
+      "".join(
+        json.dumps(record.to_dict(), sort_keys=True) + "\n"
+        for record in sorted(records, key=lambda item: item.work_id)
+      ),
+      encoding="utf-8",
+    )
+
   def test_refresh_check_and_stale_detection(self) -> None:
     manifest = refresh_model(
       self.bib,
@@ -264,6 +312,191 @@ class ArtifactTests(unittest.TestCase):
     self.bib.write_text(self.bib.read_text(encoding="utf-8").replace("Useful biology result.", "Changed result."), encoding="utf-8")
     with self.assertRaises(StaleModelError):
       check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_active_issue_negative_extends_the_effective_negative_class(self) -> None:
+    self.write_issue_negatives(self.issue_negative(
+      work_id="doi:10.9999/irrelevant",
+      title="An irrelevant clinical report",
+      abstract="This report concerns an unrelated therapeutic intervention.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["negative_count"], 1)
+    self.assertEqual(manifest["issue_negative_count"], 1)
+    self.assertEqual(manifest["effective_negative_count"], 2)
+    rows = [
+      json.loads(line)
+      for line in (self.artifacts / ISSUE_NEGATIVE_MANIFEST)
+      .read_text(encoding="utf-8")
+      .splitlines()
+    ]
+    self.assertEqual(len(rows), 1)
+    self.assertTrue(rows[0]["active"])
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_duplicate_issue_provenance_does_not_change_model_version(self) -> None:
+    feedback = self.issue_negative(
+      work_id="doi:10.9999/irrelevant",
+      title="An irrelevant clinical report",
+      abstract="This report concerns an unrelated therapeutic intervention.",
+    )
+    self.write_issue_negatives(feedback)
+    original = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.write_issue_negatives(
+      replace(
+        feedback,
+        issue_numbers=(101, 102),
+        issue_urls=(
+          "https://github.com/delalamo/SKM/issues/101",
+          "https://github.com/delalamo/SKM/issues/102",
+        ),
+      )
+    )
+    updated = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertNotEqual(
+      original["issue_negative_snapshot_hash"],
+      updated["issue_negative_snapshot_hash"],
+    )
+    self.assertNotEqual(
+      original["issue_negative_corpus_hash"],
+      updated["issue_negative_corpus_hash"],
+    )
+    self.assertEqual(
+      original["issue_negative_training_hash"],
+      updated["issue_negative_training_hash"],
+    )
+    self.assertEqual(original["model_hash"], updated["model_hash"])
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_fit_omits_issue_negative_that_is_in_the_bibliography(self) -> None:
+    # The collector should normally mark this omission. The model repeats the
+    # identity check so a stale or incorrectly marked snapshot cannot give a
+    # bibliography paper negative weight.
+    self.write_issue_negatives(self.issue_negative(
+      work_id="doi:10.1234/useful",
+      title="A stale issue copy of the useful paper",
+      abstract="Stale issue text that must not enter the negative class.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(manifest["effective_negative_count"], 1)
+    self.assertEqual(
+      manifest["issue_negative_bibliography_overlap_count"], 1
+    )
+    self.assertEqual(
+      manifest["issue_negative_omission_counts"],
+      {"bibliography_overlap": 1},
+    )
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_fit_omits_issue_negative_already_in_the_fixed_corpus(self) -> None:
+    self.write_issue_negatives(self.issue_negative(
+      work_id="pmid:12345",
+      title="A duplicate fixed negative",
+      abstract="Different text cannot bypass the stable PMID identity.",
+    ))
+
+    manifest = refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+
+    self.assertEqual(manifest["issue_negative_count"], 0)
+    self.assertEqual(manifest["effective_negative_count"], 1)
+    self.assertEqual(manifest["issue_negative_fixed_overlap_count"], 1)
+    check_model(self.bib, self.artifacts, strict_negative_quotas=False)
+
+  def test_check_model_accepts_legacy_artifacts_as_empty_feedback(self) -> None:
+    import numpy as np
+
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    manifest_path = self.artifacts / "model_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    with np.load(self.artifacts / "classifier.npz", allow_pickle=False) as model:
+      coefficients = np.asarray(model["coef"], dtype=np.float64)
+      intercept = float(np.asarray(model["intercept"])[0])
+    for field in list(manifest):
+      if field.startswith("issue_negative_"):
+        manifest.pop(field)
+    manifest.pop("effective_negative_count")
+    manifest["model_hash"] = _model_hash(
+      coefficients,
+      intercept,
+      manifest["bibliography_hash"],
+      manifest["negative_corpus_file_hash"],
+      manifest["negative_metadata_file_hash"],
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    for filename in (
+      ISSUE_NEGATIVE_CORPUS,
+      ISSUE_NEGATIVE_MATRIX,
+      ISSUE_NEGATIVE_MANIFEST,
+    ):
+      (self.artifacts / filename).unlink()
+
+    checked = check_model(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+    self.assertEqual(checked["model_hash"], manifest["model_hash"])
+
+  def test_check_detects_issue_negative_artifact_tampering(self) -> None:
+    import numpy as np
+
+    self.write_issue_negatives(self.issue_negative(
+      work_id="doi:10.9999/irrelevant",
+      title="An irrelevant clinical report",
+      abstract="This report concerns an unrelated therapeutic intervention.",
+    ))
+    refresh_model(
+      self.bib,
+      self.artifacts,
+      encoder=self.FakeEncoder(),
+      strict_negative_quotas=False,
+    )
+    matrix_path = self.artifacts / ISSUE_NEGATIVE_MATRIX
+    matrix = np.load(matrix_path, allow_pickle=False)
+    matrix[0, 0] += 0.25
+    np.save(matrix_path, matrix, allow_pickle=False)
+
+    errors = model_errors(
+      self.bib, self.artifacts, strict_negative_quotas=False
+    )
+    self.assertTrue(
+      any("issue_negative_matrix_hash" in error for error in errors),
+      errors,
+    )
 
   def test_positive_row_is_stable_when_abstract_changes(self) -> None:
     refresh_model(self.bib, self.artifacts, encoder=self.FakeEncoder(), strict_negative_quotas=False)

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -43,6 +43,28 @@ def test_fork_never_enters_the_credentialed_auto_refresh_path() -> None:
   assert not decision.sensitive_change
 
 
+def test_non_bibliography_change_never_enters_auto_refresh() -> None:
+  decision = classify_paths(
+    ["paper_relevance/README.md"],
+    event_name="pull_request",
+    same_repository=True,
+  )
+
+  assert not decision.auto_refresh
+  assert not decision.sensitive_change
+
+
+def test_manual_dispatch_is_verify_only_even_for_bibliography() -> None:
+  decision = classify_paths(
+    ["bibliography.bib"],
+    event_name="workflow_dispatch",
+    same_repository=True,
+  )
+
+  assert not decision.auto_refresh
+  assert not decision.sensitive_change
+
+
 @pytest.mark.parametrize(
   "path",
   [
@@ -50,6 +72,9 @@ def test_fork_never_enters_the_credentialed_auto_refresh_path() -> None:
     "paperbot.toml",
     "requirements-paperbot.lock",
     ".github/workflows/paper-model-refresh.yml",
+    ".gitattributes",
+    "paper_relevance/.gitattributes",
+    ".lfsconfig",
     "paper_relevance/pubmed_negatives_v1.jsonl",
     "paper_relevance/pubmed_negatives_v1_metadata.json",
     # Retain fail-closed handling for the retired corpus path.
@@ -176,6 +201,8 @@ def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
   assert "candidate/requirements-paperbot.lock" in tests_job
   assert "steps.dependencies.outputs.bootstrap == 'true'" in tests_job
   assert "tests/paperbot/test_no_remote_summarization.py" in tests_job
+  assert "working-directory: candidate" in tests_job
+  assert "run: python -m pytest tests/paperbot" in tests_job
   assert "check-model" in tests_job
   assert "secrets." not in tests_job
   assert "git push" not in tests_job
@@ -185,6 +212,34 @@ def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
   assert "Initial paperbot bootstrap is validated by the credential-free test job" in (
     refresh_job
   )
+
+
+def test_workflow_triggers_for_paperbot_test_changes() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+
+  trigger = workflow.split("  workflow_dispatch:", maxsplit=1)[0]
+  assert "    paths:" not in trigger
+  assert "Detect paperbot-relevant changes" in workflow
+  assert ":(glob)tests/paperbot/**" in workflow
+  assert "name: Test paperbot without credentials" in workflow
+  assert "if: always()" in workflow
+
+
+def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+  gate = workflow.split("  paperbot_test_gate:", maxsplit=1)[1].split(
+    "  refresh-or-verify:", maxsplit=1
+  )[0]
+
+  assert "needs: [detect_paperbot_changes, paperbot_tests]" in gate
+  assert "DETECT_RESULT" in gate
+  assert '"$DETECT_RESULT" != "success"' in gate
+  assert '"$RELEVANT" == "true" && "$TEST_RESULT" != "success"' in gate
+  assert '"$RELEVANT" != "true" && "$RELEVANT" != "false"' in gate
 
 
 def test_workflow_scopes_tokens_to_their_required_steps() -> None:
@@ -211,6 +266,26 @@ def test_workflow_scopes_tokens_to_their_required_steps() -> None:
   assert "MODEL_UPDATE_TOKEN" not in sync_step
 
   assert "MODEL_UPDATE_TOKEN: ${{ secrets.MODEL_UPDATE_TOKEN }}" in commit_and_after
+  assert '--force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA"' in commit_and_after
+  assert '"HEAD:refs/heads/$HEAD_REF"' in commit_and_after
+
+
+def test_workflow_stages_exactly_the_generated_allowlist() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+  stage_block = workflow.split(
+    "          git -C candidate add -- \\", maxsplit=1
+  )[1].split(
+    "          if git -C candidate diff --cached --quiet;", maxsplit=1
+  )[0]
+  staged = {
+    line.strip().removesuffix("\\").strip()
+    for line in stage_block.splitlines()
+    if line.strip()
+  }
+
+  assert staged == GENERATED_PATHS
 
 
 def test_every_automatic_model_refresh_first_synchronizes_issue_feedback() -> None:

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -74,6 +75,7 @@ def test_manual_dispatch_is_verify_only_even_for_bibliography() -> None:
     "paperbot.toml",
     "requirements-paperbot.lock",
     ".github/workflows/paper-model-refresh.yml",
+    ".github/CODEOWNERS",
     ".gitattributes",
     "paper_relevance/.gitattributes",
     ".lfsconfig",
@@ -193,6 +195,28 @@ def test_workflow_routes_push_and_validation_through_trusted_policy() -> None:
     assert path in workflow
 
 
+def test_sensitive_paperbot_paths_require_maintainer_code_ownership() -> None:
+  codeowners = Path(".github/CODEOWNERS").read_text(encoding="utf-8")
+  expected = {
+    "/.github/CODEOWNERS",
+    "/.github/workflows/paper-*.yml",
+    "/paperbot.toml",
+    "/requirements-paperbot.lock",
+    "/scripts/paperbot/",
+    "/paper_relevance/",
+    "/tests/paperbot/",
+  }
+  rules = {
+    line.split()[0]: tuple(line.split()[1:])
+    for line in codeowners.splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+  }
+
+  assert expected.issubset(rules)
+  for path in expected:
+    assert rules[path] == ("@delalamo",)
+
+
 def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
   workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
     encoding="utf-8"
@@ -204,7 +228,9 @@ def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
   assert "steps.dependencies.outputs.bootstrap == 'true'" in tests_job
   assert "tests/paperbot/test_no_remote_summarization.py" in tests_job
   assert "working-directory: candidate" in tests_job
-  assert "run: python -m pytest tests/paperbot" in tests_job
+  assert "env -u PYTHONPATH python -P -c" in tests_job
+  assert "import pytest,sys; sys.path.insert(0, \".\")" in tests_job
+  assert "pytest.main([\"tests/paperbot\"])" in tests_job
   assert "check-model" in tests_job
   assert "secrets." not in tests_job
   assert "git push" not in tests_job
@@ -223,13 +249,587 @@ def test_workflow_triggers_for_paperbot_test_changes() -> None:
 
   trigger = workflow.split("  workflow_dispatch:", maxsplit=1)[0]
   assert "    paths:" not in trigger
+  assert "  merge_group:" in trigger
   assert "Detect paperbot-relevant changes" in workflow
-  assert ":(glob)tests/paperbot/**" in workflow
+  for relevant_path in (
+    ":(glob)tests/paperbot/**",
+    ":(glob)**/.gitignore",
+    ":(glob)**/.pytest.ini",
+    ":(glob)**/.pytest.toml",
+    ":(glob)**/conftest.py",
+    ":(glob)**/pyproject.toml",
+    ":(glob)**/pytest.ini",
+    ":(glob)**/pytest.toml",
+    ":(glob)**/setup.cfg",
+    ":(glob)**/tox.ini",
+    ":(glob)*.py",
+    ":(glob)**/*.py",
+    ":(glob)*.py[cod]",
+    ":(glob)**/*.py[cod]",
+    ":(glob)*.so",
+    ":(glob)**/*.so",
+    ":(glob)*.pyd",
+    ":(glob)**/*.pyd",
+    ":(glob)*.dylib",
+    ":(glob)**/*.dylib",
+    ".github/CODEOWNERS",
+    "sitecustomize.py",
+    "usercustomize.py",
+  ):
+    assert relevant_path in workflow
+  assert 'case "$lock_status" in' in workflow
+  assert 'case "$relevant_status" in' in workflow
   assert "name: Test paperbot without credentials" in workflow
   assert "if: always()" in workflow
 
 
-def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() -> None:
+def test_workflow_wires_detection_and_required_gate_outputs_exactly() -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  detect = workflow["jobs"]["detect_paperbot_changes"]
+  assert detect["outputs"] == {
+    "relevant": "${{ steps.changes.outputs.relevant }}",
+    "lock_changed": "${{ steps.changes.outputs.lock_changed }}",
+  }
+  assert detect["env"] == {
+    "BASE_SHA": (
+      "${{ github.event.pull_request.base.sha || "
+      "github.event.merge_group.base_sha || github.sha }}"
+    ),
+    "HEAD_SHA": (
+      "${{ github.event.pull_request.head.sha || "
+      "github.event.merge_group.head_sha || github.sha }}"
+    ),
+  }
+  detect_checkout = next(
+    step
+    for step in detect["steps"]
+    if step["name"] == "Check out candidate history"
+  )
+  expected_candidate_checkout = {
+    "repository": (
+      "${{ github.event.pull_request.head.repo.full_name || "
+      "github.repository }}"
+    ),
+    "ref": "${{ github.event.pull_request.head.sha || github.sha }}",
+    "path": "candidate",
+    "persist-credentials": False,
+  }
+  for key, expected in expected_candidate_checkout.items():
+    assert detect_checkout["with"][key] == expected
+  assert detect_checkout["with"]["fetch-depth"] == 0
+
+  selector = next(
+    step
+    for step in workflow["jobs"]["paperbot_tests"]["steps"]
+    if step["name"] == "Select dependency source"
+  )
+  assert selector["env"]["LOCK_CHANGED"] == (
+    "${{ needs.detect_paperbot_changes.outputs.lock_changed }}"
+  )
+  install = next(
+    step
+    for step in workflow["jobs"]["paperbot_tests"]["steps"]
+    if step["name"] == "Install pinned dependencies"
+  )
+  assert install["run"] == (
+    'python -m pip install --requirement '
+    '"${{ steps.dependencies.outputs.lock }}"'
+  )
+  test_steps = workflow["jobs"]["paperbot_tests"]["steps"]
+  assert test_steps.index(install) < next(
+    index
+    for index, step in enumerate(test_steps)
+    if step["name"] == "Verify model with trusted code under selected dependencies"
+  )
+  test_checkout = next(
+    step
+    for step in test_steps
+    if step["name"] == "Check out candidate code"
+  )
+  assert test_checkout["with"] == expected_candidate_checkout
+
+  gate = workflow["jobs"]["paperbot_test_gate"]
+  assert gate["if"] == "always()"
+  assert gate["needs"] == [
+    "detect_paperbot_changes",
+    "paperbot_tests",
+    "refresh-or-verify",
+  ]
+  assert gate["steps"][0]["env"] == {
+    "DETECT_RESULT": "${{ needs.detect_paperbot_changes.result }}",
+    "RELEVANT": "${{ needs.detect_paperbot_changes.outputs.relevant }}",
+    "TEST_RESULT": "${{ needs.paperbot_tests.result }}",
+    "REFRESH_RESULT": "${{ needs.refresh-or-verify.result }}",
+  }
+
+  refresh_checkout = next(
+    step
+    for step in workflow["jobs"]["refresh-or-verify"]["steps"]
+    if step["name"] == "Check out candidate bibliography"
+  )
+  for key, expected in expected_candidate_checkout.items():
+    assert refresh_checkout["with"][key] == expected
+  assert refresh_checkout["with"]["fetch-depth"] == 0
+
+
+@pytest.mark.parametrize(
+  ("event_name", "expected_lock_changed"),
+  [
+    ("workflow_dispatch", "true"),
+    ("merge_group", "true"),
+  ],
+)
+def test_non_pr_event_detection_is_fail_closed(
+  tmp_path: Path,
+  event_name: str,
+  expected_lock_changed: str,
+) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  output = tmp_path / "github-output"
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "GITHUB_EVENT_NAME": event_name,
+      "GITHUB_OUTPUT": str(output),
+    },
+  )
+
+  assert completed.returncode == 0, completed.stderr
+  values = output.read_text(encoding="utf-8")
+  assert "relevant=true" in values
+  assert f"lock_changed={expected_lock_changed}" in values
+
+
+def test_pr_change_detection_propagates_git_failures(tmp_path: Path) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  executable_dir = tmp_path / "bin"
+  executable_dir.mkdir()
+  fake_git = executable_dir / "git"
+  fake_git.write_text(
+    "#!/usr/bin/env bash\n"
+    '[[ "$*" == *" fetch "* ]] && exit 0\n'
+    "exit 128\n",
+    encoding="utf-8",
+  )
+  fake_git.chmod(0o755)
+  output = tmp_path / "github-output"
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "BASE_SHA": "a" * 40,
+      "GITHUB_EVENT_NAME": "pull_request",
+      "GITHUB_OUTPUT": str(output),
+      "GITHUB_REPOSITORY": "delalamo/SKM",
+      "HEAD_SHA": "b" * 40,
+      "PATH": f"{executable_dir}{os.pathsep}{os.environ['PATH']}",
+    },
+  )
+
+  assert completed.returncode == 128
+  assert "Could not inspect changed Git object modes" in (
+    completed.stdout + completed.stderr
+  )
+
+
+@pytest.mark.parametrize(
+  ("changed_path", "symlink_target"),
+  [
+    ("numpy", "scripts/paperbot"),
+    ("scripts.pyc", None),
+    ("scripts.cpython-312-x86_64-linux-gnu.so", None),
+  ],
+)
+def test_pr_change_detection_treats_import_shadows_as_relevant(
+  tmp_path: Path,
+  changed_path: str,
+  symlink_target: str | None,
+) -> None:
+  candidate = tmp_path / "candidate"
+  candidate.mkdir()
+  _git(candidate, "init")
+  _git(candidate, "config", "user.name", "Paperbot Test")
+  _git(candidate, "config", "user.email", "paperbot@example.invalid")
+  (candidate / "README.md").write_text("base\n", encoding="utf-8")
+  _git(candidate, "add", ".")
+  _git(candidate, "commit", "-m", "base")
+  base = _git(candidate, "rev-parse", "HEAD")
+  changed = candidate / changed_path
+  if symlink_target is None:
+    changed.write_bytes(b"importable shadow fixture\n")
+  else:
+    changed.symlink_to(symlink_target)
+  _git(candidate, "add", "-f", changed_path)
+  _git(candidate, "commit", "-m", "importable package symlink")
+  head = _git(candidate, "rev-parse", "HEAD")
+
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  executable_dir = tmp_path / "bin"
+  executable_dir.mkdir()
+  fake_git = executable_dir / "git"
+  real_git = shutil.which("git")
+  assert real_git is not None
+  fake_git.write_text(
+    "#!/usr/bin/env bash\n"
+    'if [[ "$1" == "-C" && "$3" == "fetch" ]]; then exit 0; fi\n'
+    f'exec "{real_git}" "$@"\n',
+    encoding="utf-8",
+  )
+  fake_git.chmod(0o755)
+  output = tmp_path / "github-output"
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    cwd=tmp_path,
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "BASE_SHA": base,
+      "GITHUB_EVENT_NAME": "pull_request",
+      "GITHUB_OUTPUT": str(output),
+      "GITHUB_REPOSITORY": "delalamo/SKM",
+      "HEAD_SHA": head,
+      "PATH": f"{executable_dir}{os.pathsep}{os.environ['PATH']}",
+    },
+  )
+
+  assert completed.returncode == 0, completed.stderr
+  values = output.read_text(encoding="utf-8")
+  assert "lock_changed=false" in values
+  assert "relevant=true" in values
+
+
+def test_symlink_detection_cannot_mask_a_later_git_failure(
+  tmp_path: Path,
+) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  executable_dir = tmp_path / "bin"
+  executable_dir.mkdir()
+  fake_git = executable_dir / "git"
+  fake_git.write_text(
+    "#!/usr/bin/env bash\n"
+    '[[ "$*" == *" fetch "* ]] && exit 0\n'
+    'if [[ "$*" == *" --raw "* ]]; then\n'
+    "  printf ':000000 120000 0000000 1111111 A\\tnumpy\\n'\n"
+    "  exit 0\n"
+    "fi\n"
+    '[[ "$*" == *"bibliography.bib"* ]] && exit 128\n'
+    '[[ "$*" == *"requirements-paperbot.lock"* ]] && exit 0\n'
+    "exit 128\n",
+    encoding="utf-8",
+  )
+  fake_git.chmod(0o755)
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "BASE_SHA": "a" * 40,
+      "GITHUB_EVENT_NAME": "pull_request",
+      "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+      "GITHUB_REPOSITORY": "delalamo/SKM",
+      "HEAD_SHA": "b" * 40,
+      "PATH": f"{executable_dir}{os.pathsep}{os.environ['PATH']}",
+    },
+  )
+
+  assert completed.returncode == 128
+  assert "Could not determine whether paperbot-relevant paths changed" in (
+    completed.stdout + completed.stderr
+  )
+
+
+def test_changed_dependency_lock_is_tested_in_the_candidate_environment(
+  tmp_path: Path,
+) -> None:
+  workspace = tmp_path / "workspace"
+  trusted = workspace / "trusted"
+  candidate = workspace / "candidate"
+  (trusted / "scripts" / "paperbot").mkdir(parents=True)
+  candidate.mkdir(parents=True)
+  (trusted / "requirements-paperbot.lock").write_text(
+    "trusted==1\n", encoding="utf-8"
+  )
+  (trusted / "scripts" / "paperbot" / "pr_safety.py").write_text(
+    "# trusted\n", encoding="utf-8"
+  )
+  (candidate / "requirements-paperbot.lock").write_text(
+    "candidate==2\n", encoding="utf-8"
+  )
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["paperbot_tests"]["steps"]
+    if step["name"] == "Select dependency source"
+  )
+
+  for changed, expected_lock in (
+    ("false", "trusted/requirements-paperbot.lock"),
+    ("true", "candidate/requirements-paperbot.lock"),
+  ):
+    output = tmp_path / f"github-output-{changed}"
+    completed = subprocess.run(
+      ["bash", "-c", step["run"]],
+      check=False,
+      capture_output=True,
+      text=True,
+      env={
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_WORKSPACE": str(workspace),
+        "LOCK_CHANGED": changed,
+      },
+    )
+    assert completed.returncode == 0, completed.stderr
+    values = output.read_text(encoding="utf-8")
+    assert f"lock={expected_lock}" in values
+    assert "bootstrap=false" in values
+
+
+def test_candidate_dependencies_never_enter_the_credentialed_refresh_job() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+  tests_job, refresh_job = workflow.split("  refresh-or-verify:", maxsplit=1)
+
+  assert (
+    "Verify model with trusted code under selected dependencies"
+    in tests_job
+  )
+  assert 'working-directory: trusted' in tests_job
+  assert '--repo-root "$GITHUB_WORKSPACE/candidate"' in tests_job
+  assert "candidate/requirements-paperbot.lock" in tests_job
+
+  assert "--requirement trusted/requirements-paperbot.lock" in refresh_job
+  assert "--requirement candidate/requirements-paperbot.lock" not in refresh_job
+  assert "steps.refresh_dependencies" not in refresh_job
+
+
+def test_safe_path_prevents_candidate_pytest_module_shadowing(
+  tmp_path: Path,
+) -> None:
+  candidate = tmp_path / "candidate"
+  tests = candidate / "tests" / "paperbot"
+  tests.mkdir(parents=True)
+  scripts = candidate / "scripts"
+  scripts.mkdir()
+  (scripts / "__init__.py").write_text("", encoding="utf-8")
+  (scripts / "sentinel.py").write_text("VALUE = 42\n", encoding="utf-8")
+  (candidate / "pytest.py").write_text(
+    "raise SystemExit(0)\n", encoding="utf-8"
+  )
+  (tests / "test_must_run.py").write_text(
+    "from scripts.sentinel import VALUE\n\n"
+    "def test_must_run():\n"
+    "  assert VALUE == 42\n"
+    "  assert False, 'the real pytest runner collected this test'\n",
+    encoding="utf-8",
+  )
+
+  unsafe = subprocess.run(
+    [os.sys.executable, "-m", "pytest", "tests/paperbot"],
+    cwd=candidate,
+    check=False,
+    capture_output=True,
+    text=True,
+    env={**os.environ, "PYTHONPATH": str(candidate)},
+  )
+  safe = subprocess.run(
+    [
+      "env",
+      "-u",
+      "PYTHONPATH",
+      os.sys.executable,
+      "-P",
+      "-c",
+      (
+        'import pytest,sys; sys.path.insert(0, "."); '
+        'raise SystemExit(pytest.main(["tests/paperbot"]))'
+      ),
+    ],
+    cwd=candidate,
+    check=False,
+    capture_output=True,
+    text=True,
+    env={**os.environ, "PYTHONPATH": str(candidate)},
+  )
+
+  assert unsafe.returncode == 0
+  assert safe.returncode == 1
+  assert "the real pytest runner collected this test" in (
+    safe.stdout + safe.stderr
+  )
+
+
+def test_full_base_history_is_used_for_triple_dot_diffs() -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  detect_script = next(
+    step["run"]
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  classify_script = next(
+    step["run"]
+    for step in workflow["jobs"]["refresh-or-verify"]["steps"]
+    if step["name"] == "Classify the pull request"
+  )
+  for script in (detect_script, classify_script):
+    assert "fetch --no-tags" in script
+    assert "--depth" not in script
+  assert '"$BASE_SHA...$HEAD_SHA"' in detect_script
+
+
+def test_full_base_fetch_supports_a_diverged_pull_request(
+  tmp_path: Path,
+) -> None:
+  upstream = tmp_path / "upstream.git"
+  _git(tmp_path, "init", "--bare", str(upstream))
+
+  maintainer = tmp_path / "maintainer"
+  maintainer.mkdir()
+  _git(maintainer, "init")
+  _git(maintainer, "config", "user.name", "Paperbot Test")
+  _git(maintainer, "config", "user.email", "paperbot@example.invalid")
+  (maintainer / "README.md").write_text("base\n", encoding="utf-8")
+  _git(maintainer, "add", ".")
+  _git(maintainer, "commit", "-m", "base")
+  _git(maintainer, "branch", "-M", "main")
+  _git(maintainer, "remote", "add", "origin", str(upstream))
+  _git(maintainer, "push", "-u", "origin", "main")
+
+  candidate = tmp_path / "candidate"
+  _git(
+    tmp_path,
+    "clone",
+    "--branch",
+    "main",
+    str(upstream),
+    str(candidate),
+  )
+  _git(candidate, "config", "user.name", "Paperbot Test")
+  _git(candidate, "config", "user.email", "paperbot@example.invalid")
+  _git(candidate, "checkout", "-b", "feature")
+  (candidate / "scripts" / "paperbot").mkdir(parents=True)
+  (candidate / "scripts" / "paperbot" / "model.py").write_text(
+    "feature = True\n", encoding="utf-8"
+  )
+  _git(candidate, "add", ".")
+  _git(candidate, "commit", "-m", "feature")
+  head = _git(candidate, "rev-parse", "HEAD")
+
+  (maintainer / "README.md").write_text("base advanced\n", encoding="utf-8")
+  _git(maintainer, "commit", "-am", "advance main")
+  base = _git(maintainer, "rev-parse", "HEAD")
+  _git(maintainer, "push", "origin", "main")
+
+  _git(candidate, "fetch", "--no-tags", str(upstream), base)
+  completed = subprocess.run(
+    [
+      "git",
+      "-C",
+      str(candidate),
+      "diff",
+      "--quiet",
+      "--no-renames",
+      f"{base}...{head}",
+      "--",
+      "scripts/paperbot/model.py",
+    ],
+    check=False,
+    capture_output=True,
+    text=True,
+  )
+
+  assert completed.returncode == 1, completed.stderr
+
+
+def test_dependency_source_rejects_invalid_change_detection(
+  tmp_path: Path,
+) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["paperbot_tests"]["steps"]
+    if step["name"] == "Select dependency source"
+  )
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+      "GITHUB_WORKSPACE": str(tmp_path),
+      "LOCK_CHANGED": "",
+    },
+  )
+  assert completed.returncode == 1
+
+
+def test_required_paperbot_gate_cannot_pass_after_required_job_failure() -> None:
   workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
     encoding="utf-8"
   )
@@ -237,10 +837,14 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
     "  refresh-or-verify:", maxsplit=1
   )[0]
 
-  assert "needs: [detect_paperbot_changes, paperbot_tests]" in gate
+  assert (
+    "needs: [detect_paperbot_changes, paperbot_tests, refresh-or-verify]"
+    in gate
+  )
   assert "DETECT_RESULT" in gate
   assert '"$DETECT_RESULT" != "success"' in gate
   assert '"$RELEVANT" == "true" && "$TEST_RESULT" != "success"' in gate
+  assert '"$RELEVANT" == "true" && "$REFRESH_RESULT" != "success"' in gate
   assert '"$RELEVANT" != "true" && "$RELEVANT" != "false"' in gate
 
 
@@ -252,6 +856,7 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
         "DETECT_RESULT": "success",
         "RELEVANT": "false",
         "TEST_RESULT": "skipped",
+        "REFRESH_RESULT": "skipped",
       },
       0,
     ),
@@ -260,6 +865,7 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
         "DETECT_RESULT": "success",
         "RELEVANT": "true",
         "TEST_RESULT": "success",
+        "REFRESH_RESULT": "success",
       },
       0,
     ),
@@ -268,6 +874,16 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
         "DETECT_RESULT": "success",
         "RELEVANT": "true",
         "TEST_RESULT": "failure",
+        "REFRESH_RESULT": "success",
+      },
+      1,
+    ),
+    (
+      {
+        "DETECT_RESULT": "success",
+        "RELEVANT": "true",
+        "TEST_RESULT": "success",
+        "REFRESH_RESULT": "failure",
       },
       1,
     ),
@@ -276,6 +892,7 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
         "DETECT_RESULT": "failure",
         "RELEVANT": "",
         "TEST_RESULT": "skipped",
+        "REFRESH_RESULT": "skipped",
       },
       1,
     ),
@@ -329,6 +946,54 @@ def test_workflow_scopes_tokens_to_their_required_steps() -> None:
   assert "MODEL_UPDATE_TOKEN: ${{ secrets.MODEL_UPDATE_TOKEN }}" in commit_and_after
   assert '--force-with-lease="refs/heads/$HEAD_REF:$HEAD_SHA"' in commit_and_after
   assert '"HEAD:refs/heads/$HEAD_REF"' in commit_and_after
+  assert (
+    commit_and_after.index("git -C candidate diff --cached --quiet")
+    < commit_and_after.index('[[ -z "$MODEL_UPDATE_TOKEN" ]]')
+  )
+
+
+def test_noop_refresh_does_not_require_model_update_token(
+  tmp_path: Path,
+) -> None:
+  candidate = tmp_path / "candidate"
+  candidate.mkdir()
+  _git(candidate, "init")
+  _git(candidate, "config", "user.name", "Paperbot Test")
+  _git(candidate, "config", "user.email", "paperbot@example.invalid")
+  for relative in GENERATED_PATHS:
+    path = candidate / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"fixture\n")
+  _git(candidate, "add", ".")
+  _git(candidate, "commit", "-m", "current artifacts")
+
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["refresh-or-verify"]["steps"]
+    if step["name"] == "Commit refreshed artifacts to trusted PR branch"
+  )
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    cwd=tmp_path,
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "HEAD_REF": "feature",
+      "HEAD_REPOSITORY": "delalamo/SKM",
+      "HEAD_SHA": _git(candidate, "rev-parse", "HEAD"),
+      "MODEL_UPDATE_TOKEN": "",
+    },
+  )
+
+  assert completed.returncode == 0, completed.stderr
+  assert "already current" in completed.stdout
 
 
 def test_workflow_stages_exactly_the_generated_allowlist() -> None:

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -191,10 +191,14 @@ def test_workflow_scopes_tokens_to_their_required_steps() -> None:
   workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
     encoding="utf-8"
   )
+  tests_job, refresh_job = workflow.split("  refresh-or-verify:", maxsplit=1)
 
   before_commit, commit_and_after = workflow.split(
     "      - name: Commit refreshed artifacts to trusted PR branch", maxsplit=1
   )
+  assert "issues: read" not in tests_job
+  assert "GITHUB_TOKEN:" not in tests_job
+  assert "permissions:\n      contents: read\n      issues: read" in refresh_job
   assert "GITHUB_TOKEN: ${{ github.token }}" in before_commit
   assert workflow.count("GITHUB_TOKEN: ${{ github.token }}") == 1
   assert "MODEL_UPDATE_TOKEN" not in before_commit
@@ -202,7 +206,31 @@ def test_workflow_scopes_tokens_to_their_required_steps() -> None:
   sync_step = before_commit.split(
     "      - name: Synchronize closed negative issues", maxsplit=1
   )[1].split("      - name: Refresh and verify model", maxsplit=1)[0]
+  assert "steps.safety.outputs.auto_refresh == 'true'" in sync_step
   assert "GITHUB_TOKEN: ${{ github.token }}" in sync_step
   assert "MODEL_UPDATE_TOKEN" not in sync_step
 
   assert "MODEL_UPDATE_TOKEN: ${{ secrets.MODEL_UPDATE_TOKEN }}" in commit_and_after
+
+
+def test_every_automatic_model_refresh_first_synchronizes_issue_feedback() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+  backfill_step = workflow.split(
+    "      - name: Backfill bibliography abstracts", maxsplit=1
+  )[1].split("      - name: Synchronize closed negative issues", maxsplit=1)[0]
+  sync_step = workflow.split(
+    "      - name: Synchronize closed negative issues", maxsplit=1
+  )[1].split("      - name: Refresh and verify model", maxsplit=1)[0]
+  refresh_step = workflow.split(
+    "      - name: Refresh and verify model", maxsplit=1
+  )[1].split("      - name: Reject unexpected generated paths", maxsplit=1)[0]
+
+  automatic_condition = "steps.safety.outputs.auto_refresh == 'true'"
+  assert automatic_condition in backfill_step
+  assert automatic_condition in sync_step
+  assert automatic_condition in refresh_step
+  assert "backfill-bibliography" in backfill_step
+  assert "sync-issue-negatives" in sync_step
+  assert "refresh-model" in refresh_step

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.paperbot.pr_safety import (
   GENERATED_MODEL_PATHS,
@@ -240,6 +242,65 @@ def test_required_paperbot_gate_cannot_pass_after_detection_or_test_failure() ->
   assert '"$DETECT_RESULT" != "success"' in gate
   assert '"$RELEVANT" == "true" && "$TEST_RESULT" != "success"' in gate
   assert '"$RELEVANT" != "true" && "$RELEVANT" != "false"' in gate
+
+
+@pytest.mark.parametrize(
+  ("environment", "expected"),
+  [
+    (
+      {
+        "DETECT_RESULT": "success",
+        "RELEVANT": "false",
+        "TEST_RESULT": "skipped",
+      },
+      0,
+    ),
+    (
+      {
+        "DETECT_RESULT": "success",
+        "RELEVANT": "true",
+        "TEST_RESULT": "success",
+      },
+      0,
+    ),
+    (
+      {
+        "DETECT_RESULT": "success",
+        "RELEVANT": "true",
+        "TEST_RESULT": "failure",
+      },
+      1,
+    ),
+    (
+      {
+        "DETECT_RESULT": "failure",
+        "RELEVANT": "",
+        "TEST_RESULT": "skipped",
+      },
+      1,
+    ),
+  ],
+)
+def test_required_gate_shell_logic(
+  environment: dict[str, str],
+  expected: int,
+) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  script = workflow["jobs"]["paperbot_test_gate"]["steps"][0]["run"]
+
+  completed = subprocess.run(
+    ["bash", "-c", script],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={**os.environ, **environment},
+  )
+
+  assert completed.returncode == expected
 
 
 def test_workflow_scopes_tokens_to_their_required_steps() -> None:

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -73,6 +73,12 @@ def test_sensitive_inputs_and_generated_artifacts_disable_auto_refresh(
 def test_generated_allowlist_fails_closed() -> None:
   validate_generated_paths(GENERATED_PATHS)
 
+  assert {
+    "paper_relevance/issue_negatives.jsonl",
+    "paper_relevance/issue_negative_embeddings.npy",
+    "paper_relevance/issue_negative_manifest.jsonl",
+  }.issubset(GENERATED_MODEL_PATHS)
+
   with pytest.raises(UnexpectedGeneratedPaths) as caught:
     validate_generated_paths(["bibliography.bib", "content/unexpected.md"])
 
@@ -145,6 +151,19 @@ def test_workflow_routes_push_and_validation_through_trusted_policy() -> None:
   assert "cache: pip" not in workflow
   assert 'PAPERBOT_DISABLE_ARBITRARY_HTML: "1"' in workflow
   assert "-L \"$GITHUB_WORKSPACE/candidate/bibliography.bib\"" in workflow
+  assert "issues: read" in workflow
+
+  backfill = workflow.index("backfill-bibliography")
+  sync = workflow.index("sync-issue-negatives")
+  refresh = workflow.index("refresh-model")
+  assert backfill < sync < refresh
+
+  for path in (
+    "paper_relevance/issue_negatives.jsonl",
+    "paper_relevance/issue_negative_embeddings.npy",
+    "paper_relevance/issue_negative_manifest.jsonl",
+  ):
+    assert path in workflow
 
 
 def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
@@ -166,3 +185,24 @@ def test_workflow_bootstrap_is_credential_free_and_read_only() -> None:
   assert "Initial paperbot bootstrap is validated by the credential-free test job" in (
     refresh_job
   )
+
+
+def test_workflow_scopes_tokens_to_their_required_steps() -> None:
+  workflow = Path(".github/workflows/paper-model-refresh.yml").read_text(
+    encoding="utf-8"
+  )
+
+  before_commit, commit_and_after = workflow.split(
+    "      - name: Commit refreshed artifacts to trusted PR branch", maxsplit=1
+  )
+  assert "GITHUB_TOKEN: ${{ github.token }}" in before_commit
+  assert workflow.count("GITHUB_TOKEN: ${{ github.token }}") == 1
+  assert "MODEL_UPDATE_TOKEN" not in before_commit
+
+  sync_step = before_commit.split(
+    "      - name: Synchronize closed negative issues", maxsplit=1
+  )[1].split("      - name: Refresh and verify model", maxsplit=1)[0]
+  assert "GITHUB_TOKEN: ${{ github.token }}" in sync_step
+  assert "MODEL_UPDATE_TOKEN" not in sync_step
+
+  assert "MODEL_UPDATE_TOKEN: ${{ secrets.MODEL_UPDATE_TOKEN }}" in commit_and_after

--- a/tests/paperbot/test_records.py
+++ b/tests/paperbot/test_records.py
@@ -125,6 +125,41 @@ def test_deduplicate_revisions_uses_latest_version_metadata() -> None:
   assert merged[0].created_at == first.created_at
 
 
+def test_deduplicate_full_ties_are_independent_of_provider_order() -> None:
+  common = {
+    "source_id": "shared",
+    "abstract": "Same-length abstract.",
+    "authors": ("Smith, Ada",),
+    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    "updated_at": datetime(2026, 1, 1, tzinfo=UTC),
+    "doi": "10.1234/shared",
+    "version": "1",
+  }
+  pubmed = PaperRecord(
+    source="pubmed",
+    title="Alpha title",
+    venue="Journal A",
+    url="https://example.test/a",
+    license="Licence A",
+    metadata={"provider_value": "alpha"},
+    **common,
+  )
+  crossref = PaperRecord(
+    source="crossref",
+    title="Bravo title",
+    venue="Journal B",
+    url="https://example.test/b",
+    license="Licence B",
+    metadata={"provider_value": "bravo"},
+    **common,
+  )
+
+  forward = deduplicate_records([pubmed, crossref])[0].to_dict()
+  reverse = deduplicate_records([crossref, pubmed])[0].to_dict()
+
+  assert forward == reverse
+
+
 def test_preprint_publication_relationship_merges_transitively() -> None:
   preprint = paper(related_ids=("doi:10.1000/final",))
   pubmed = PaperRecord(

--- a/tests/paperbot/test_records.py
+++ b/tests/paperbot/test_records.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from itertools import permutations
 
 from scripts.paperbot.records import (
   PaperRecord,
@@ -229,6 +230,52 @@ def test_preprint_publication_fallback_allows_two_year_indexing_lag() -> None:
 
   assert len(merged) == 1
   assert merged[0].doi == "10.1016/j.crmeth.2026.101468"
+
+
+def test_revised_preprint_titles_do_not_choose_a_publication_by_order() -> None:
+  preprint_old = paper(
+    title="Original preprint title",
+    abstract="Original preprint abstract.",
+    metadata={"publication_year": 2022},
+  )
+  preprint_new = paper(
+    title="Revised preprint title",
+    abstract="Revised preprint abstract.",
+    metadata={"publication_year": 2022},
+  )
+  publication_old = paper(
+    source="pubmed",
+    source_id="publication-old",
+    title=preprint_old.title,
+    abstract="First plausible publication.",
+    doi="10.1000/old-title",
+    pmid="1001",
+    metadata={"publication_year": 2023},
+  )
+  publication_new = paper(
+    source="pubmed",
+    source_id="publication-new",
+    title=preprint_new.title,
+    abstract="Second plausible publication.",
+    doi="10.1000/new-title",
+    pmid="1002",
+    metadata={"publication_year": 2024},
+  )
+  records = (
+    preprint_old,
+    preprint_new,
+    publication_old,
+    publication_new,
+  )
+  expected_ids = {
+    "doi:10.1101/2026.01.01.123456",
+    "doi:10.1000/old-title",
+    "doi:10.1000/new-title",
+  }
+
+  for ordering in permutations(records):
+    merged = deduplicate_records(ordering)
+    assert {record.canonical_id for record in merged} == expected_ids
 
 
 def test_research_square_fallback_prefers_version_of_record_doi() -> None:


### PR DESCRIPTION
## Summary

- collect closed, paperbot-managed GitHub issues carrying the case-insensitive **negative** label before every trusted bibliography/model refresh
- validate managed issue metadata and collapse duplicate issues, identifier aliases, revisions, and preprint/publication pairs to one negative training work
- exclude any issue-derived work already present in **bibliography.bib** or the fixed PubMed negative corpus, both during collection and again immediately before fitting
- retain append-only SPECTER2 feedback embeddings while activating/deactivating rows as issues are closed, reopened, labeled, or unlabelled
- fit the existing deterministic logistic regression on the fixed negatives plus active human-feedback negatives
- add manifest hashes/counts, legacy-artifact compatibility, a dedicated CLI command, trusted workflow wiring, security allowlists, and mandatory paperbot tests

## Why

Closed papers explicitly labeled **negative** are direct relevance feedback. Using them in subsequent bibliography-triggered model refreshes should make the ranking progressively more topic-specific without treating ordinary closed/read issues as negative examples or double-counting duplicate paper threads.

The bibliography is authoritative: if a previously rejected paper is later added there, it is recorded as an overlap but receives no negative training weight.

## Final hostile audit

The audit reviewed the new collector/model path and the bibliography parser, backfill pipeline, model artifact loader, configuration boundary, record merging, and workflow context around it. It added fail-closed handling for:

- malformed BibTeX, managed issue markers, duplicate issue numbers/keys/fields, conflicting identities, and stale overlap provenance
- overlap with every bibliography alias and fixed negative—not merely a canonical representative
- orphaned, partial, mismatched, or stale matrices/manifests/classifiers, with safe full-rebuild recovery
- source-destroying bibliography rewrites, empty resolver output, comments/braces/percent escapes, and nondeterministic record ties
- config paths or symlink parents escaping the repository
- shallow-history change detection, Git failures, no-op token handling, fake local pytest, root/recursive bytecode or native-extension shadowing, and candidate dependencies crossing into credentialed jobs

The trusted refresh order is:

1. backfill bibliography abstracts
2. synchronize closed negative issues with the job-scoped, read-only GITHUB_TOKEN
3. refresh and verify embeddings/model
4. stage only the exact generated-artifact allowlist

Fork PRs and PRs changing paperbot code, dependency pins, workflows, or model artifacts remain verify-only. MODEL_UPDATE_TOKEN is exposed only to the final commit/push step, and a no-op refresh never requires it.

## Validation

- **304/304 tests passed** on GitHub's Ubuntu/Python 3.12 runner; the parser suite also passed **76 subtests** locally
- committed model passes independent deterministic refit and artifact verification: 669 positives, 669 fixed negatives, model hash **6b34a393890b72e05ad16c023dcb22b267a36e1ba3e2b287952c7a1bcb3819e8**
- real bibliography dry-run: 670 entries → 669 canonical works, 0 additions, 0 unresolved, no file change
- no-remote-summarization policy, Python compilation, workflow YAML parsing, and git diff checks pass
- two independent line-by-line audits found no remaining concrete defect
- exact head **385f072c6bb69fc842711d4e5b00df8215c85a8e**: paperbot, duplicate, and site workflows are green: https://github.com/delalamo/SKM/actions/runs/30165054296

## Rollout and enforcement

This code PR intentionally leaves the currently committed legacy model artifacts unchanged so the default-branch trusted verifier can review the implementation safely. After merge, the next trusted bibliography refresh will generate and commit issue_negatives.jsonl, issue_negative_embeddings.npy, issue_negative_manifest.jsonl, and the corresponding updated classifier/manifest.

CODEOWNERS now requires @delalamo review for the paperbot workflow, code, dependency lock, model data, configuration, and tests. For mandatory merge enforcement, the exact check **Test paperbot without credentials** must also be saved as a required main branch-protection check. The check exists and is green on this PR; saving that repository setting still requires the owner's GitHub sudo/passkey confirmation.