### PR TITLE
Fix paperbot duplicate issue detection

### DIFF
--- a/scripts/paperbot/github.py
+++ b/scripts/paperbot/github.py
@@ -108,23 +108,41 @@ class ManagedIssue:
 
 @dataclass
 class ManagedIssueIndex:
-    """Lookup table for every open and closed paperbot-managed issue."""
+    """Canonical lookups for trusted open and closed paperbot issues.
+
+    Exact duplicate work IDs are retained in ``duplicates`` but excluded from
+    canonical lookups and reconciliation.
+    """
 
     issues: list[ManagedIssue] = field(default_factory=list)
+    duplicates: list[ManagedIssue] = field(default_factory=list)
     by_alias: dict[str, ManagedIssue] = field(default_factory=dict)
     by_work_id: dict[str, ManagedIssue] = field(default_factory=dict)
     reserved_bibkeys: set[str] = field(default_factory=set)
 
     def add(self, issue: ManagedIssue) -> None:
-        self.issues.append(issue)
         work_id = str(issue.meta.get("work_id", ""))
+        bibkey = str(issue.meta.get("bibkey", ""))
+        if bibkey:
+            self.reserved_bibkeys.add(bibkey.casefold())
+        incumbent = self.by_work_id.get(work_id) if work_id else None
+        if incumbent is not None and incumbent.number != issue.number:
+            # Legacy local runs authenticated as the repository owner, while
+            # scheduled runs authenticate as github-actions. If both created
+            # the same work before owner-authored issues were indexed, retain
+            # the oldest issue as canonical and prevent any further copies.
+            for alias in issue.meta.get("aliases", []):
+                self._claim(
+                    self.by_alias, normalize_alias(str(alias)), incumbent
+                )
+            self.duplicates.append(issue)
+            return
+
+        self.issues.append(issue)
         if work_id:
             self._claim(self.by_work_id, work_id, issue)
         for alias in issue.meta.get("aliases", []):
             self._claim(self.by_alias, normalize_alias(str(alias)), issue)
-        bibkey = str(issue.meta.get("bibkey", ""))
-        if bibkey:
-            self.reserved_bibkeys.add(bibkey.casefold())
 
     @staticmethod
     def _claim(
@@ -464,13 +482,21 @@ def ensure_paper_label(client: GitHubClient) -> None:
 def load_managed_issues(client: GitHubClient) -> ManagedIssueIndex:
     index = ManagedIssueIndex()
     # Search all issues so removing a label cannot make the next run duplicate a
-    # managed paper thread. Pull requests are filtered by GitHubClient. Check
-    # authorship before parsing the marker so public users cannot claim aliases
-    # or make malformed marker text abort discovery.
+    # managed paper thread. Pull requests are filtered by GitHubClient. Trust
+    # both Actions and the repository owner because the supported local runner
+    # creates issues as the owner. Check authorship before parsing the marker so
+    # other public users cannot claim aliases or make malformed marker text
+    # abort discovery.
+    trusted_logins = {GITHUB_ACTIONS_BOT_LOGIN}
+    repository = str(getattr(client, "repo", "") or "")
+    owner, separator, _name = repository.partition("/")
+    if separator and owner:
+        trusted_logins.add(owner.casefold())
+    managed: list[ManagedIssue] = []
     for raw in client.list_issues(label=None):
         author = raw.get("user")
         login = str(author.get("login", "") if isinstance(author, Mapping) else "")
-        if login.casefold() != GITHUB_ACTIONS_BOT_LOGIN:
+        if login.casefold() not in trusted_logins:
             continue
         body = str(raw.get("body") or "")
         meta = parse_managed_meta(body)
@@ -488,7 +514,9 @@ def load_managed_issues(client: GitHubClient) -> ManagedIssueIndex:
                 f"Managed paper issue #{number} must contain exactly one "
                 "complete paperbot block"
             )
-        index.add(_managed_issue_from_api(raw, meta))
+        managed.append(_managed_issue_from_api(raw, meta))
+    for issue in sorted(managed, key=lambda item: item.number):
+        index.add(issue)
     return index
 
 

--- a/tests/paperbot/test_github.py
+++ b/tests/paperbot/test_github.py
@@ -48,6 +48,7 @@ class Paper:
 
 class MemoryIssueClient:
     def __init__(self, issues: list[dict[str, Any]] | None = None) -> None:
+        self.repo = "delalamo/SKM"
         self.issues = deepcopy(issues or [])
         self.calls: list[tuple[Any, ...]] = []
         self.comments: dict[int, list[dict[str, Any]]] = {}
@@ -454,9 +455,17 @@ def test_public_issue_reads_need_no_token_but_mutations_do() -> None:
         client.create_issue(title="No", body="No")
 
 
-def test_alias_collision_between_issues_fails_closed() -> None:
+def test_alias_collision_between_distinct_works_fails_closed() -> None:
     first = paper_issue(Paper())
-    second = deepcopy(first)
+    second = paper_issue(
+        Paper(
+            doi="10.1000/other",
+            pmid="67890",
+            arxiv_id="2501.99999",
+            source_id="10.1000/other",
+            aliases=("doi:10.1000/test",),
+        )
+    )
     second["number"] = 5
     second["node_id"] = "ISSUE_5"
     client = MemoryIssueClient([first, second])
@@ -481,6 +490,43 @@ def test_bot_authored_malformed_managed_body_fails_before_deduplication(
 
     with pytest.raises(GitHubError, match="metadata marker|complete paperbot block"):
         load_managed_issues(MemoryIssueClient([issue]))
+
+
+def test_repository_owner_managed_issue_prevents_duplicate_creation() -> None:
+    legacy = paper_issue(Paper())
+    legacy["user"] = {"login": "delalamo", "type": "User"}
+    client = MemoryIssueClient([legacy])
+
+    index = load_managed_issues(client)
+    result = upsert_paper_issue(
+        client,
+        Paper(),
+        0.7,
+        "@article{Lovelace2026,\n  title = {A useful paper}\n}",
+        "Lovelace2026",
+        index=index,
+        model_hash="model-v1",
+    )
+
+    assert index.find(Paper()).number == 4
+    assert result.action == "unchanged"
+    assert not any(call[0] == "create_issue" for call in client.calls)
+
+
+def test_exact_duplicate_work_keeps_oldest_issue_canonical() -> None:
+    legacy = paper_issue(Paper())
+    legacy["user"] = {"login": "delalamo", "type": "User"}
+    duplicate = deepcopy(legacy)
+    duplicate["number"] = 5
+    duplicate["node_id"] = "ISSUE_5"
+    duplicate["user"] = {"login": "github-actions[bot]", "type": "Bot"}
+    client = MemoryIssueClient([duplicate, legacy])
+
+    index = load_managed_issues(client)
+
+    assert [issue.number for issue in index.issues] == [4]
+    assert [issue.number for issue in index.duplicates] == [5]
+    assert index.find(Paper()).number == 4
 
 
 def test_user_authored_marker_cannot_claim_aliases_or_be_mutated() -> None:


### PR DESCRIPTION
## Summary

- recognize paperbot-managed issues created by the repository owner as well as `github-actions`
- keep the oldest issue canonical when multiple managed issues share the same work ID
- retain later exact duplicates for diagnostics while excluding them from reconciliation
- continue failing closed when aliases collide across genuinely different works

## Root cause

The supported local paper-discovery runner creates issues as the repository owner, while scheduled runs authenticate as `github-actions`. The managed-issue loader trusted only `github-actions`, so it ignored owner-created issue #335 and created issue #351 for the same DOI.

## Impact

Future runs recognize legacy owner-created paper issues and update the oldest canonical issue instead of opening another copy. Untrusted user-authored metadata markers remain excluded.

## Validation

- `python -m pytest tests/paperbot -q`
- 263 passed, 43 skipped, 66 subtests passed
