### PR TITLE
Fix bibliography refresh validation in pull requests

### DIFF
--- a/.github/workflows/paper-model-refresh.yml
+++ b/.github/workflows/paper-model-refresh.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       relevant: ${{ steps.changes.outputs.relevant }}
       lock_changed: ${{ steps.changes.outputs.lock_changed }}
+      bibliography_changed: ${{ steps.changes.outputs.bibliography_changed }}
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
@@ -45,6 +46,9 @@ jobs:
             # Manual dispatch can target a feature branch. Validate that
             # branch's lock in the credential-free job conservatively.
             echo "lock_changed=true" >> "$GITHUB_OUTPUT"
+            # Manual runs do not have a pull-request diff whose later refresh
+            # job can be trusted to reconcile.
+            echo "bibliography_changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
@@ -53,6 +57,8 @@ jobs:
             # Testing its assembled head with the candidate lock is the safe
             # conservative choice.
             echo "lock_changed=true" >> "$GITHUB_OUTPUT"
+            # Merge groups must already contain refreshed model artifacts.
+            echo "bibliography_changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
@@ -86,6 +92,9 @@ jobs:
           git -C candidate diff --quiet --no-renames \
             "$BASE_SHA...$HEAD_SHA" -- requirements-paperbot.lock
           lock_status=$?
+          git -C candidate diff --quiet --no-renames \
+            "$BASE_SHA...$HEAD_SHA" -- bibliography.bib
+          bibliography_status=$?
           git -C candidate diff --quiet --no-renames \
             "$BASE_SHA...$HEAD_SHA" -- \
               bibliography.bib \
@@ -133,6 +142,14 @@ jobs:
             *)
               echo "::error::Could not determine whether the dependency lock changed"
               exit "$lock_status"
+              ;;
+          esac
+          case "$bibliography_status" in
+            0) echo "bibliography_changed=false" >> "$GITHUB_OUTPUT" ;;
+            1) echo "bibliography_changed=true" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Could not determine whether the bibliography changed"
+              exit "$bibliography_status"
               ;;
           esac
           case "$relevant_status" in
@@ -229,7 +246,9 @@ jobs:
           raise SystemExit(pytest.main(["tests/paperbot"]))'
 
       - name: Verify model with trusted code under selected dependencies
-        if: steps.dependencies.outputs.bootstrap != 'true'
+        if: >-
+          steps.dependencies.outputs.bootstrap != 'true' &&
+          needs.detect_paperbot_changes.outputs.bibliography_changed != 'true'
         working-directory: trusted
         env:
           PYTHONPATH: ${{ github.workspace }}/trusted
@@ -237,6 +256,14 @@ jobs:
           python -m scripts.paperbot
           --repo-root "$GITHUB_WORKSPACE/candidate"
           check-model
+
+      - name: Defer model freshness to bibliography refresh
+        if: >-
+          steps.dependencies.outputs.bootstrap != 'true' &&
+          needs.detect_paperbot_changes.outputs.bibliography_changed == 'true'
+        run: >-
+          echo "The pull request changes bibliography.bib;
+          the refresh-or-verify job will regenerate and validate the model artifacts."
 
       - name: Verify initial candidate model and policy
         if: steps.dependencies.outputs.bootstrap == 'true'

--- a/tests/paperbot/test_pr_safety.py
+++ b/tests/paperbot/test_pr_safety.py
@@ -293,6 +293,9 @@ def test_workflow_wires_detection_and_required_gate_outputs_exactly() -> None:
   assert detect["outputs"] == {
     "relevant": "${{ steps.changes.outputs.relevant }}",
     "lock_changed": "${{ steps.changes.outputs.lock_changed }}",
+    "bibliography_changed": (
+      "${{ steps.changes.outputs.bibliography_changed }}"
+    ),
   }
   assert detect["env"] == {
     "BASE_SHA": (
@@ -344,6 +347,24 @@ def test_workflow_wires_detection_and_required_gate_outputs_exactly() -> None:
     index
     for index, step in enumerate(test_steps)
     if step["name"] == "Verify model with trusted code under selected dependencies"
+  )
+  verify_model = next(
+    step
+    for step in test_steps
+    if step["name"] == "Verify model with trusted code under selected dependencies"
+  )
+  assert verify_model["if"] == (
+    "steps.dependencies.outputs.bootstrap != 'true' && "
+    "needs.detect_paperbot_changes.outputs.bibliography_changed != 'true'"
+  )
+  deferred_model = next(
+    step
+    for step in test_steps
+    if step["name"] == "Defer model freshness to bibliography refresh"
+  )
+  assert deferred_model["if"] == (
+    "steps.dependencies.outputs.bootstrap != 'true' && "
+    "needs.detect_paperbot_changes.outputs.bibliography_changed == 'true'"
   )
   test_checkout = next(
     step
@@ -415,6 +436,7 @@ def test_non_pr_event_detection_is_fail_closed(
   values = output.read_text(encoding="utf-8")
   assert "relevant=true" in values
   assert f"lock_changed={expected_lock_changed}" in values
+  assert "bibliography_changed=false" in values
 
 
 def test_pr_change_detection_propagates_git_failures(tmp_path: Path) -> None:
@@ -459,6 +481,56 @@ def test_pr_change_detection_propagates_git_failures(tmp_path: Path) -> None:
   assert "Could not inspect changed Git object modes" in (
     completed.stdout + completed.stderr
   )
+
+
+def test_pr_change_detection_reports_bibliography_changes(
+  tmp_path: Path,
+) -> None:
+  workflow = yaml.safe_load(
+    Path(".github/workflows/paper-model-refresh.yml").read_text(
+      encoding="utf-8"
+    )
+  )
+  step = next(
+    step
+    for step in workflow["jobs"]["detect_paperbot_changes"]["steps"]
+    if step["name"] == "Detect relevant paths"
+  )
+  executable_dir = tmp_path / "bin"
+  executable_dir.mkdir()
+  fake_git = executable_dir / "git"
+  fake_git.write_text(
+    "#!/usr/bin/env bash\n"
+    '[[ "$*" == *" fetch "* ]] && exit 0\n'
+    '[[ "$*" == *" --raw "* ]] && exit 0\n'
+    '[[ "$*" == *"-- requirements-paperbot.lock" ]] && exit 0\n'
+    '[[ "$*" == *"-- bibliography.bib" ]] && exit 1\n'
+    "exit 1\n",
+    encoding="utf-8",
+  )
+  fake_git.chmod(0o755)
+  output = tmp_path / "github-output"
+  completed = subprocess.run(
+    ["bash", "-c", step["run"]],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+      **os.environ,
+      "BASE_SHA": "a" * 40,
+      "GITHUB_EVENT_NAME": "pull_request",
+      "GITHUB_OUTPUT": str(output),
+      "GITHUB_REPOSITORY": "delalamo/SKM",
+      "HEAD_SHA": "b" * 40,
+      "PATH": f"{executable_dir}{os.pathsep}{os.environ['PATH']}",
+    },
+  )
+
+  assert completed.returncode == 0, completed.stderr
+  values = output.read_text(encoding="utf-8")
+  assert "lock_changed=false" in values
+  assert "bibliography_changed=true" in values
+  assert "relevant=true" in values
 
 
 @pytest.mark.parametrize(
@@ -535,6 +607,7 @@ def test_pr_change_detection_treats_import_shadows_as_relevant(
   assert completed.returncode == 0, completed.stderr
   values = output.read_text(encoding="utf-8")
   assert "lock_changed=false" in values
+  assert "bibliography_changed=false" in values
   assert "relevant=true" in values
 
 
@@ -584,7 +657,7 @@ def test_symlink_detection_cannot_mask_a_later_git_failure(
   )
 
   assert completed.returncode == 128
-  assert "Could not determine whether paperbot-relevant paths changed" in (
+  assert "Could not determine whether the bibliography changed" in (
     completed.stdout + completed.stderr
   )
 


### PR DESCRIPTION
## Summary

- detect when a pull request changes `bibliography.bib`
- defer the pre-refresh model-freshness assertion for those pull requests
- keep model validation in the trusted refresh-or-verify job
- retain fail-closed checks for merge queues, manual runs, and non-bibliography changes
- add workflow safety coverage for the new detection and routing behavior

## Root cause

A pull request that adds bibliography entries necessarily carries model artifacts generated from the previous bibliography until the trusted refresh job runs. The credential-free test job treated this expected intermediate state as a failure even though the refresh-or-verify job owns regeneration and final validation.

## Validation

- `python -m pytest tests/paperbot/test_pr_safety.py` — 57 passed
- `git diff --check origin/main...HEAD`