### PR TITLE
Make paper discovery resilient to feed throttling

### DIFF
--- a/scripts/paperbot/daily.py
+++ b/scripts/paperbot/daily.py
@@ -136,8 +136,24 @@ class DailyResult:
   publish_errors: tuple[str, ...]
 
   @property
+  def blocking_feed_errors(self) -> tuple[Mapping[str, Any], ...]:
+    """Return feed failures that make this tranche incomplete without recovery."""
+
+    has_recovery_overlap = datetime.fromisoformat(self.query_since) < datetime.fromisoformat(
+      self.logical_since
+    )
+    if not has_recovery_overlap:
+      return self.feed_errors
+    return tuple(
+      error
+      for error in self.feed_errors
+      if error.get("retryable") is not True
+      or self.source_counts.get(str(error.get("source") or ""), 0) <= 0
+    )
+
+  @property
   def ok(self) -> bool:
-    return not self.feed_errors and not self.publish_errors
+    return not self.blocking_feed_errors and not self.publish_errors
 
   def to_dict(self) -> dict[str, Any]:
     return {
@@ -153,6 +169,7 @@ class DailyResult:
       "action_counts": _counts(result.action for result in self.candidates),
       "candidates": [result.to_dict() for result in self.candidates],
       "feed_errors": list(self.feed_errors),
+      "blocking_feed_errors": list(self.blocking_feed_errors),
       "publish_errors": list(self.publish_errors),
     }
 
@@ -175,7 +192,10 @@ def run_daily(
 
   Model integrity is checked before a label, issue, comment, state, or Project
   write is attempted. Feed errors are retained while successful providers are
-  still processed; callers should use ``DailyResult.ok`` as the exit status.
+  still processed. A retryable partial-provider failure is recoverable when the
+  run has a query overlap; zero-result, non-retryable, and exact-backfill
+  failures remain blocking. Callers should use ``DailyResult.ok`` as the exit
+  status.
   """
 
   project_enabled = project_configuration_enabled(config)

--- a/scripts/paperbot/github.py
+++ b/scripts/paperbot/github.py
@@ -535,8 +535,8 @@ def upsert_paper_issue(
     """Create or reconcile the one managed issue for *record*.
 
     New papers at or below the strict cutoff are skipped. Existing papers are
-    updated regardless of score so revisions can be surfaced and closed issues
-    can be reopened.
+    updated regardless of score so revisions can be surfaced, but a user's
+    decision to close an issue is preserved.
     """
 
     if not 0.0 <= float(score) <= 1.0:
@@ -613,12 +613,10 @@ def upsert_paper_issue(
                 f"{revision_marker}",
             )
     body = replace_managed_block(existing.body, managed_body)
-    state = "open" if substantive and existing.state == "closed" else None
     raw = client.update_issue(
         existing.number,
         title=title if title_changed else None,
         body=body,
-        state=state,
     )
     issue = _managed_issue_from_api(raw, meta)
     action = "updated" if substantive or identity_changed or title_changed else "rescored"

--- a/scripts/paperbot/sources.py
+++ b/scripts/paperbot/sources.py
@@ -52,6 +52,7 @@ OPENSEARCH = "{http://a9.com/-/spec/opensearch/1.1/}"
 # wildcard intentionally precedes the dot and covers both the archive and all
 # modern subcategories.  stat has only dotted subject classes.
 ARXIV_CATEGORY_FAMILIES = ("q-bio*", "cond-mat*", "stat.*")
+ARXIV_PAGE_SIZE = 500
 RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 SENSITIVE_QUERY_KEYS = frozenset(
   {"api_key", "apikey", "token", "access_token", "client_secret"}
@@ -890,9 +891,13 @@ def fetch_arxiv(
   window: FetchWindow,
   client: HttpClientProtocol,
   *,
-  page_size: int = 100,
+  page_size: int = ARXIV_PAGE_SIZE,
   categories: Sequence[str] = ARXIV_CATEGORY_FAMILIES,
 ) -> SourceResult:
+  # arXiv permits slices of up to 2,000 results. A moderate default keeps
+  # responses bounded while avoiding five requests where one is sufficient
+  # for a typical recovery window, reducing exposure to shared-IP throttling.
+  page_size = min(max(1, page_size), 1_000)
   result = SourceResult("arxiv")
   category_query = " OR ".join(f"cat:{category}" for category in categories)
   start_stamp = window.query_since.strftime("%Y%m%d%H%M")

--- a/tests/paperbot/test_daily.py
+++ b/tests/paperbot/test_daily.py
@@ -14,6 +14,7 @@ from scripts.paperbot.config import PaperbotConfig
 from scripts.paperbot.cli import main as paperbot_main
 from scripts.paperbot.daily import (
   BibliographyIndex,
+  DailyResult,
   _managed_pubmed_ids,
   _prepare_candidates,
   run_daily,
@@ -123,7 +124,8 @@ def report(records: list[PaperRecord], *, failed: bool = False) -> FetchReport:
     if failed
     else ()
   )
-  return FetchReport(window, tuple(records), errors, {"fixture": len(records)})
+  counts = {"arxiv": len(records)} if failed else {"fixture": len(records)}
+  return FetchReport(window, tuple(records), errors, counts)
 
 
 @pytest.mark.parametrize(
@@ -154,8 +156,48 @@ def test_daily_uses_strict_cutoff_and_reports_partial_feed_failure(
     )
 
   assert result.candidates[0].action == action
-  assert not result.ok
+  assert result.ok
   assert result.feed_errors[0]["source"] == "arxiv"
+  assert result.blocking_feed_errors == ()
+
+
+@pytest.mark.parametrize(
+  ("retryable", "source_count", "manual_backfill"),
+  [
+    (False, 1, False),
+    (True, 0, False),
+    (True, 1, True),
+  ],
+)
+def test_daily_keeps_unrecoverable_feed_failures_blocking(
+  retryable: bool, source_count: int, manual_backfill: bool
+) -> None:
+  window = FetchWindow.ending_at(datetime(2026, 7, 22, tzinfo=UTC))
+  if manual_backfill:
+    window = FetchWindow.between(window.logical_since, window.until)
+  failure = {
+    "source": "arxiv",
+    "operation": "page at 100",
+    "message": "unavailable",
+    "retryable": retryable,
+    "status": 429 if retryable else 400,
+  }
+  result = DailyResult(
+    as_of=window.until.isoformat(),
+    logical_since=window.logical_since.isoformat(),
+    query_since=window.query_since.isoformat(),
+    dry_run=False,
+    model_hash="model",
+    source_counts={"arxiv": source_count},
+    fetched_count=source_count,
+    stale_open_issues=0,
+    candidates=(),
+    feed_errors=(failure,),
+    publish_errors=(),
+  )
+
+  assert not result.ok
+  assert result.blocking_feed_errors == (failure,)
 
 
 def test_candidate_key_collision_uses_b_and_known_work_reuses_key(tmp_path: Path) -> None:

--- a/tests/paperbot/test_github.py
+++ b/tests/paperbot/test_github.py
@@ -334,7 +334,7 @@ def test_new_issue_is_labeled_and_contains_copyable_bibtex() -> None:
     assert result.issue.body.index("**Date:**") < result.issue.body.index("## Abstract")
 
 
-def test_revision_updates_managed_block_comments_once_and_reopens() -> None:
+def test_revision_updates_closed_issue_without_reopening() -> None:
     original = Paper(version="v1", updated="2026-07-21", abstract="Old abstract")
     client = MemoryIssueClient(
         [
@@ -359,7 +359,8 @@ def test_revision_updates_managed_block_comments_once_and_reopens() -> None:
 
     assert result.action == "updated"
     assert result.substantive_change
-    assert client.issues[0]["state"] == "open"
+    assert client.issues[0]["state"] == "closed"
+    assert next(call for call in client.calls if call[0] == "update_issue")[4] is None
     assert client.issues[0]["body"].startswith("Personal finding\n\n")
     assert client.issues[0]["body"].endswith("\n\nDo not overwrite")
     assert len(client.comments[4]) == 1

--- a/tests/paperbot/test_sources.py
+++ b/tests/paperbot/test_sources.py
@@ -10,6 +10,7 @@ import pytest
 from scripts.paperbot.records import PaperRecord
 from scripts.paperbot.sources import (
   ARXIV_API,
+  ARXIV_PAGE_SIZE,
   CHEMRXIV_API,
   CHEMRXIV_CROSSREF_API,
   CHEMRXIV_FALLBACK_API,
@@ -402,6 +403,16 @@ def test_parse_and_paginate_arxiv_by_last_updated_date() -> None:
   assert len(result.records) == 2
   assert [call[2]["start"] for call in client.calls] == [0, 1]
   assert all(call[3] == 3.1 for call in client.calls)
+
+
+def test_arxiv_uses_a_larger_bounded_default_page() -> None:
+  client = RoutingClient(bytes_route=lambda _url, _params: arxiv_xml())
+
+  result = fetch_arxiv(window(), client)
+
+  assert result.ok
+  assert client.calls[0][2]["max_results"] == ARXIV_PAGE_SIZE
+  assert ARXIV_PAGE_SIZE == 500
 
 
 @pytest.mark.parametrize("server", ["biorxiv", "medrxiv"])


### PR DESCRIPTION
## Summary

- request arXiv results in 500-record pages to reduce API calls and shared-runner rate-limit exposure
- keep retryable partial feed errors in the run report without failing a scheduled tranche that has recovery overlap
- preserve the state of closed paper issues when metadata changes or a paper is scraped again
- add regression coverage for the recoverable and still-fatal feed cases, the arXiv page size, and closed-issue updates

## What went wrong

The [August 3 daily discovery run](https://github.com/delalamo/SKM/actions/runs/30776839250) fetched the first 100 arXiv records, then exhausted the HTTP client retries after arXiv returned `429 Too Many Requests` for the page at offset 100. The other sources completed, and the run still fetched 1,226 candidates, created 2 issues, and updated 5. However, `DailyResult.ok` treated every feed error as fatal, so the useful partial run exited with status 1.

Separately, `upsert_paper_issue` explicitly sent `state: open` whenever a closed issue received a substantive metadata revision. A new paper version or an overlapping re-scrape could therefore override a manual close.

## Why this should not recur

arXiv now uses 500-record pages, cutting the normal request count by up to 80% while staying well below the [documented 2,000-record slice limit](https://info.arxiv.org/help/api/user-manual.html#3112-start-and-max_results-paging).

If a provider still returns a retryable error after returning some records, a scheduled run with the normal 72-hour recovery window records the error as a warning instead of failing. The next scheduled tranche re-fetches the overlap and fills the gap idempotently. Non-retryable errors, providers that return no records, exact manual backfills without recovery overlap, and publishing errors still fail the run.

Issue updates no longer send a state transition. Paperbot can refresh its managed metadata and add a revision comment, but a closed issue remains closed on every later scrape.

## Validation

- `312 passed` in the complete paperbot test suite under Python 3.12 and the pinned dependencies
- committed relevance model verification passed
- staged diff whitespace validation passed
