### PR TITLE
docs: replace Quartz README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,1 @@
-# Quartz v4
-
-> “[One] who works with the door open gets all kinds of interruptions, but [they] also occasionally gets clues as to what the world is and what might be important.” — Richard Hamming
-
-Quartz is a set of tools that helps you publish your [digital garden](https://jzhao.xyz/posts/networked-thought) and notes as a website for free.
-
-🔗 Read the documentation and get started: https://quartz.jzhao.xyz/
-
-[Join the Discord Community](https://discord.gg/cRFFHYye7t)
-
-## Sponsors
-
-<p align="center">
-  <a href="https://github.com/sponsors/jackyzha0">
-    <img src="https://cdn.jsdelivr.net/gh/jackyzha0/jackyzha0/sponsorkit/sponsors.svg" />
-  </a>
-</p>
+This repository is the source for [notes.delalamo.xyz](https://notes.delalamo.xyz), a personal zettelkasten about machine learning for protein structure, engineering and design, property prediction, and related topics. The interesting material lives in `content/notes/`, with curated tag pages in `content/tags/`, attachments in `content/assets/`, and the landing page at `content/index.md`; citations are collected in `bibliography.bib`, while the remaining configuration and source files customize the Quartz site that publishes the notes.


### PR DESCRIPTION
## Summary

Replace the upstream Quartz boilerplate README with a single repository-specific paragraph describing the zettelkasten, its structure, and the published site at [notes.delalamo.xyz](https://notes.delalamo.xyz).

## Impact

Repository visitors can immediately find the authored notes and understand where the supporting content, assets, bibliography, and Quartz customization live.

## Validation

- Confirmed the branch is one commit ahead of `main` with no divergence
- Confirmed `README.md` is the only changed file
- `git diff --check` passes