### PR TITLE
Fix kinked CDRH3 note link

### DIFF
--- a/content/notes/Kinked CDRH3 loops.md
+++ b/content/notes/Kinked CDRH3 loops.md
@@ -1,10 +1,10 @@
 ---
 title: Kinked CDRH3 loops
 created: 2026-04-10T14:02:57
-modified: "2026-04-21T07:28:09"
+modified: "2026-09-04T08:07:29"
 ---
 
-**Kinked [[Complementarity-determining regions#CDRH3|CDRH3]]** are a conformational feature found in 80-90% of human [[antibodies|antibodies]] and nearly 60% of camelid [[Nanobodies|nanobodies]] [@weitzner2015; @bahrami2023]. This occurs at the C-terminus of the loop and is [[Germline usage determines whether nanobody CDR3 is kinked of extended|dictated by germline use]]. Similar bends are found in other proteins, such as PDZ domains and peptidase C1 domains, that are involved in [[protein-protein-interactions|protein-protein interactions]] [@weitzner2015].
+**Kinked [[Complementarity-determining regions#CDRH3|CDRH3]]** are a conformational feature found in 80-90% of human [[antibodies|antibodies]] and nearly 60% of camelid [[Nanobodies|nanobodies]] [@weitzner2015; @bahrami2023]. This occurs at the C-terminus of the loop and is [[Germline usage determines whether nanobody CDR3 is kinked or extended|dictated by germline use]]. Similar bends are found in other proteins, such as PDZ domains and peptidase C1 domains, that are involved in [[protein-protein-interactions|protein-protein interactions]] [@weitzner2015].
 
 ![[Pasted-Graphic-5-1.png]]
 *Ref [@weitzner2015]*


### PR DESCRIPTION
## Summary

- correct the `of` → `or` typo in the linked note title
- restore resolution of the CDRH3 germline-usage wikilink

## Validation

- confirmed `content/notes/Germline usage determines whether nanobody CDR3 is kinked or extended.md` exists
- `git diff --check`