### PR TITLE
Hide created and modified dates on homepage

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -22,7 +22,10 @@ export const defaultContentPageLayout: PageLayout = {
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),
-    Component.ContentMeta(),
+    Component.ConditionalRender({
+      component: Component.ContentMeta(),
+      condition: (page) => page.fileData.slug !== "index",
+    }),
     Component.TagList(),
   ],
   left: [


### PR DESCRIPTION
The homepage currently displays created and modified dates below its title. Hide this metadata on the root index page by rendering ContentMeta only when the page slug is not `index`. Individual note pages continue to display their dates.

Validation: `git diff --check` and `prettier quartz.layout.ts --check` both passed.
